### PR TITLE
Fixed example to use the current rule for setting properties

### DIFF
--- a/source/docs/testing.blade.md
+++ b/source/docs/testing.blade.md
@@ -72,7 +72,7 @@ class CounterTest extends TestCase
 
         $this->assertEquals(0, $counter->count);
 
-        $counter->count = 1;
+        $counter->set('count',1);
 
         $this->assertEquals(1, $counter->count);
     }


### PR DESCRIPTION
Right now, the example shown throws will throw a 

`Livewire\Exceptions\ProtectedPropertyBindingException`

Per the source this is the correct method of setting a public property in a unit test.