### PR TITLE
Update config options table on Installation page

### DIFF
--- a/source/docs/installation.blade.md
+++ b/source/docs/installation.blade.md
@@ -90,7 +90,8 @@ php artisan vendor:publish --tag=livewire:config
 Here are the configurable options contained in this config file:
 
 Config Name | Default Value | Description
---- | ---
-"class_namespace" | "App\Http\Livewire" | The folder to install Livewire classes and look for them.
-"view_path" | `resource_path('view')` | The folder to add Livewire component views to.
-"asset_url" | null | The url to load the Livewire JavaScript assets from.
+--- | --- | ---
+class_namespace | `'App\\Http\\Livewire'` | The folder to look for Livewire classes.
+view_path | `resource_path('views/livewire')` | The folder to look for Livewire component views.
+asset_url | `null` | The url to load the Livewire JavaScript assets from.
+middleware_group | `'web'` | The middleware group that is applied every time a Livewire component is updated.


### PR DESCRIPTION
- Remove quotation marks from config keys.
- Wrap default values in `code` formatting, as they appear in `config/livewire.php`. 
- Update copy for consistency.

Hope you don't mind me doing micro-PRs btw! Thought it would be easier when deciding what you want and don't want to merge in.