### PR TITLE
Fixing a wrong example

### DIFF
--- a/source/docs/spa-mode.blade.md
+++ b/source/docs/spa-mode.blade.md
@@ -131,7 +131,7 @@ use Livewire\Component;
 
 class ShowContact extends Component
 {
-    public $contact;
+    protected $contact;
 
     public function mount(User $user)
     {


### PR DESCRIPTION
Since public properties are automatically passed to the javascript, the example will cause the following error:
```
Livewire component's [show-contact] public property [contact] must be of type: [numeric, string, array, null, or boolean]. Only protected or private properties can be set as other types because JavaScript doesn't need to access them.
```
I think making the `$contact` variable `protected` will make the example work.