### PR TITLE
Add tip about passing parameters to triggered methods

### DIFF
--- a/source/docs/triggering-actions.blade.md
+++ b/source/docs/triggering-actions.blade.md
@@ -40,6 +40,10 @@ Here are a few examples of each in HTML:
 You can listen for any event emitted by the element you are binding to. Let's say you have an element that fires a browser event called "foo", you could listen for that event like so: <code>&lt;button wire:foo="someAction"&gt;</code>
 @endtip
 
+@tip
+You can pass parameters to the triggered method from the Blade component. For example, a button such as: <code>&lt;button wire:click="someAction('parameter')"&gt;</code> will pass the parameter to the component class' method: <code>public function someAction($parameter)</code>
+@endtip
+
 ## Modifiers {#modifiers}
 
 Like you saw in the **keydown** example, Livewire directives sometimes offer "modifiers" to add extra functionality to an event. Below are the available modifiers that can be used with any event:


### PR DESCRIPTION
I couldn't find this mentioned in the docs at all, but is an extremely useful thing to be able to do, hence the tip about it.

Not sure if it could do with a more detailed description recommending to JSON-encode the parameters like `wire:click="someAction(@json($model->id))"` or with an example of a passing a Blade variable through like `wire:click="someAction('{{ $model->id }}')"` to make the syntax clear?