### PR TITLE
Fixing mobile menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1267,6 +1267,12 @@
             "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
             "dev": true
         },
+        "alpinejs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-2.0.1.tgz",
+            "integrity": "sha512-upLQQ+MFJCzAaQW7rrlOQ1YqeEpvAJspzCTIUisepv2TqayoP5dOulPxr0eW7pfs8Z/PaIcwC6OW3mmasRSjaA==",
+            "dev": true
+        },
         "animateplus": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/animateplus/-/animateplus-2.1.1.tgz",
@@ -4880,7 +4886,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -4901,12 +4908,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -4921,17 +4930,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -5048,7 +5060,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -5060,6 +5073,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -5074,6 +5088,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -5081,12 +5096,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -5105,6 +5122,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5185,7 +5203,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -5197,6 +5216,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -5282,7 +5302,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -5318,6 +5339,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -5337,6 +5359,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -5380,12 +5403,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "watch": "npm run local -- --watch"
     },
     "devDependencies": {
+        "alpinejs": "^2.0.1",
         "animateplus": "^2.1.1",
         "browser-sync": "^2.26.3",
         "browser-sync-webpack-plugin": "^2.0.1",

--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -2,6 +2,7 @@
 
 import Prism from 'prismjs'
 import animate from 'animateplus'
+import Alpine from 'alpinejs'
 
 window.animate = animate
 

--- a/source/_layouts/base.blade.php
+++ b/source/_layouts/base.blade.php
@@ -46,15 +46,18 @@
             <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
         @endif
     </head>
-    <body class="flex flex-col justify-between min-h-screen bg-gray-200 text-gray-800 leading-normal font-sans">
+    <body
+        x-data="{ mobileMenuVisible: false }"
+        class="flex flex-col justify-between min-h-screen font-sans leading-normal text-gray-800 bg-gray-200"
+    >
         @yield('content')
 
         <script src="{{ mix('js/main.js', 'assets/build') }}"></script>
 
         @stack('scripts')
 
-        <footer class="bg-white text-center text-sm mt-8 py-4" role="contentinfo">
-            <ul class="list-none flex flex-col md:flex-row justify-center">
+        <footer class="py-4 mt-8 text-sm text-center bg-white" role="contentinfo">
+            <ul class="flex flex-col justify-center list-none md:flex-row">
                 <li class="md:mr-2">
                     &copy; <a href="https://laravel-livewire.com" title="Livewire">Livewire</a> {{ date('Y') }}.
                 </li>

--- a/source/_layouts/documentation.blade.php
+++ b/source/_layouts/documentation.blade.php
@@ -11,20 +11,23 @@ $page->siteName = 'Livewire Documentation';
 @section('content')
 @yield('header')
 
-<section class="container mx-auto px-6 md:px-8 py-12 content">
-    <div class="flex flex-col-reverse md:flex-row">
-        <nav id="js-nav-menu" class="nav-menu hidden lg:block">
+<section class="container px-6 py-12 mx-auto md:px-8 content">
+    <div class="flex flex-col lg:flex-row">
+        <nav
+            class="nav-menu lg:block"
+            :class="mobileMenuVisible ? 'block' : 'hidden'"
+        >
             @include('_nav.menu', ['items' => $page->navigation])
         </nav>
 
-        <div class="w-full md:w-4/5 lg:w-3/5 break-words lg:pl-4" v-pre>
+        <div class="w-full break-words md:w-4/5 lg:w-3/5 lg:pl-4" v-pre>
             @if (strlen($page->title))
                 <h1>{!! $page->title !!}</h1>
             @endif
 
             @yield('content')
 
-            <div class="mt-12 pt-8 pb-6 border-t-2">
+            <div class="pt-8 pb-6 mt-12 border-t-2">
                 @include('_nav.footer-links', ['items' => $page->navigation])
             </div>
         </div>
@@ -34,23 +37,23 @@ $page->siteName = 'Livewire Documentation';
                 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CE7D553Y&placement=laravel-livewirecom" id="_carbonads_js"></script>
             </div>
 
-            <div class="md:pt-8 flex sm:block flex-wrap justify-around">
-                <p class="hidden sm:block font-bold mt-0 mb-4 text-gray-500 text-xs tracking-wider uppercase md:text-right">Sponsors</p>
+            <div class="flex flex-wrap justify-around md:pt-8 sm:block">
+                <p class="hidden mt-0 mb-4 text-xs font-bold tracking-wider text-gray-500 uppercase sm:block md:text-right">Sponsors</p>
 
-                <a style="height: 50px" class="block mb-3 pb-3" href="https://laravel.com/" target="_blank">
-                    <img class="md:ml-auto w-32" src="https://laravel.com/img/logotype.min.svg" alt="Laravel">
+                <a style="height: 50px" class="block pb-3 mb-3" href="https://laravel.com/" target="_blank">
+                    <img class="w-32 md:ml-auto" src="https://laravel.com/img/logotype.min.svg" alt="Laravel">
                 </a>
 
-                <a style="height: 50px" class="block mb-3 pb-3" href="https://intellow.com/" target="_blank">
-                    <img class="md:ml-auto w-32" src="/assets/img/sponsor_intellow.png" alt="Livewire Sponsor: Intellow">
+                <a style="height: 50px" class="block pb-3 mb-3" href="https://intellow.com/" target="_blank">
+                    <img class="w-32 md:ml-auto" src="/assets/img/sponsor_intellow.png" alt="Livewire Sponsor: Intellow">
                 </a>
 
-                <a style="height: 50px" class="block mb-3 pb-3" href="http://jrmerritt.com/" target="_blank">
-                    <img class="md:ml-auto w-32" src="/assets/img/sponsor_jrmerritt.png" alt="Livewire Sponsor: Intellow">
+                <a style="height: 50px" class="block pb-3 mb-3" href="http://jrmerritt.com/" target="_blank">
+                    <img class="w-32 md:ml-auto" src="/assets/img/sponsor_jrmerritt.png" alt="Livewire Sponsor: Intellow">
                 </a>
 
                 <a class="block" href="https://trustfactory.bz/" target="_blank">
-                    <img class="md:ml-auto w-32" src="/assets/img/sponsor_trustfactory.png" alt="Livewire Sponsor: Intellow">
+                    <img class="w-32 md:ml-auto" src="/assets/img/sponsor_trustfactory.png" alt="Livewire Sponsor: Intellow">
                 </a>
             </div>
         </div>

--- a/source/_layouts/master.blade.php
+++ b/source/_layouts/master.blade.php
@@ -1,35 +1,35 @@
 @extends ('_layouts.base')
 
 @section('content')
-<header class="flex items-center h-24 py-4 bg-white relative" role="banner">
-    <div class="container flex items-center mx-auto px-4 lg:px-8">
+<header class="relative flex items-center h-24 py-4 bg-white" role="banner">
+    <div class="container flex items-center px-4 mx-auto lg:px-8">
         <div class="flex items-center">
             <!-- Desktop Logo -->
-            <a href="/" title="{{ $page->siteName }} home" class="hidden md:inline-flex items-center">
+            <a href="/" title="{{ $page->siteName }} home" class="items-center hidden md:inline-flex">
                 {!! file_get_contents(__DIR__ . "/../source/assets/img/logo.svg") !!}
             </a>
             <!-- Mobile Logo -->
-            <a href="/" title="{{ $page->siteName }} home" class="inline-flex md:hidden items-center">
+            <a href="/" title="{{ $page->siteName }} home" class="inline-flex items-center md:hidden">
                 {!! file_get_contents(__DIR__ . "/../source/assets/img/logo-small.svg") !!}
             </a>
         </div>
 
-        <div class="flex flex-1 justify-end items-center text-right md:pl-10">
+        <div class="flex items-center justify-end flex-1 text-sm text-right md:pl-10 sm:text-base">
             @if ($page->docsearchApiKey && $page->docsearchIndexName)
                 @include('_nav.search-input')
             @endif
-            <a href="/docs/quickstart" class="ml-6 text-blue-800">Docs</a>
-            <a href="https://forum.laravel-livewire.com" class="ml-6 text-blue-800">Forum</a>
-            <a href="/podcast" class="ml-6 text-blue-800">Podcast</a>
+            <a href="/docs/quickstart" class="ml-3 text-blue-800 sm:ml-6">Docs</a>
+            <a href="https://forum.laravel-livewire.com" class="ml-3 text-blue-800 sm:ml-6">Forum</a>
+            <a href="/podcast" class="ml-3 text-blue-800 sm:ml-6">Podcast</a>
             <a href="https://github.com/livewire/livewire">
-                <svg class="fill-current text-blue-800 w-8 ml-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>GitHub</title><path d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0"></path></svg>
+                <svg class="w-6 ml-3 text-blue-800 fill-current sm:w-8 sm:ml-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>GitHub</title><path d="M10 0a10 10 0 0 0-3.16 19.49c.5.1.68-.22.68-.48l-.01-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.11-1.47-1.11-1.47-.9-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.9 1.52 2.34 1.08 2.91.83.1-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.1.39-1.99 1.03-2.69a3.6 3.6 0 0 1 .1-2.64s.84-.27 2.75 1.02a9.58 9.58 0 0 1 5 0c1.91-1.3 2.75-1.02 2.75-1.02.55 1.37.2 2.4.1 2.64.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.85l-.01 2.75c0 .26.18.58.69.48A10 10 0 0 0 10 0"></path></svg>
             </a>
         </div>
     </div>
 
     @yield('nav-toggle')
 
-    <div class="mb-6 absolute bottom-0 w-full" style="
+    <div class="absolute bottom-0 w-full mb-6" style="
         background-image: url(&quot;data:image/svg+xml;charset=UTF-8,%3csvg width='20px' height='12px' viewBox='0 0 20 12' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'%3e%3cg id='Artboard' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'%3e%3cpath d='M20,1 C15,1 15,11 10,11 C5,11 5,1 -1.77635684e-15,1 C-1.77635684e-15,1 -1.77635684e-15,0.666666667 -1.77635684e-15,0 L20,0 C20,0.666666667 20,1 20,1 Z' id='Line-Copy' fill='%23FFFFFF'%3e%3c/path%3e%3c/g%3e%3c/svg%3e&quot;);
         background-repeat-y: no-repeat;
         background-position-y: bottom;
@@ -38,7 +38,7 @@
     "></div>
 </header>
 
-<main role="main" class="w-full flex-auto">
+<main role="main" class="flex-auto w-full">
     @yield('content')
 </main>
 @overwrite

--- a/source/_nav/menu-toggle.blade.php
+++ b/source/_nav/menu-toggle.blade.php
@@ -1,29 +1,22 @@
-<button class="flex justify-center items-center bg-blue border border-blue h-10 mr-4 px-5 rounded-full lg:hidden focus:outline-none"
-    onclick="navMenu.toggle()"
+<button
+    class="flex items-center justify-center h-10 px-2 mr-4 border rounded-full sm:px-5 bg-blue border-blue lg:hidden focus:outline-none"
+    @click="mobileMenuVisible = !mobileMenuVisible"
 >
-    <svg id="js-nav-menu-show" xmlns="http://www.w3.org/2000/svg"
-        class="fill-current text-blue-900 h-9 w-4" viewBox="0 0 32 32"
+    <svg
+        x-show="!mobileMenuVisible"
+        xmlns="http://www.w3.org/2000/svg"
+        class="w-4 text-blue-900 fill-current h-9"
+        viewBox="0 0 32 32"
     >
         <path d="M4,10h24c1.104,0,2-0.896,2-2s-0.896-2-2-2H4C2.896,6,2,6.896,2,8S2.896,10,4,10z M28,14H4c-1.104,0-2,0.896-2,2  s0.896,2,2,2h24c1.104,0,2-0.896,2-2S29.104,14,28,14z M28,22H4c-1.104,0-2,0.896-2,2s0.896,2,2,2h24c1.104,0,2-0.896,2-2  S29.104,22,28,22z"/>
     </svg>
 
-    <svg id="js-nav-menu-hide" xmlns="http://www.w3.org/2000/svg"
-        class="hidden fill-current text-blue-900 h-9 w-4" viewBox="0 0 36 30"
+    <svg
+        x-show="mobileMenuVisible"
+        xmlns="http://www.w3.org/2000/svg"
+        class="w-4 text-blue-900 fill-current h-9"
+        viewBox="0 0 36 30"
     >
         <polygon points="32.8,4.4 28.6,0.2 18,10.8 7.4,0.2 3.2,4.4 13.8,15 3.2,25.6 7.4,29.8 18,19.2 28.6,29.8 32.8,25.6 22.2,15 "/>
     </svg>
 </button>
-
-@push('scripts')
-<script>
-    const navMenu = {
-        toggle() {
-            const menu = document.getElementById('js-nav-menu');
-            menu.classList.toggle('hidden');
-            menu.classList.toggle('lg:block');
-            document.getElementById('js-nav-menu-hide').classList.toggle('hidden');
-            document.getElementById('js-nav-menu-show').classList.toggle('hidden');
-        },
-    }
-</script>
-@endpush


### PR DESCRIPTION
Fixes #76 

I've also added Alpine (dogfooding...). Wanted to do a tiny transition when opening the menu but that's harder than I imagined. Can't use `x-show` since it only needs to apply to small screens. Without `x-show`, `x-transition` won't work.

If you prefer without alpine, let me know and I'll stip that. If you do like it, I'll be happy to PR the other ones.

Also, some class lists got re-ordered to follow a unofficial Tailwind standard (vscode plugin). If you dislike this, let me know and I'll refactor.


### Screenshots
![Sizzy-iPhone 11 localhost 26Feb 12 22](https://user-images.githubusercontent.com/884482/75340439-c9109c80-5892-11ea-9ec2-f360509c7919.png)
![Sizzy-iPhone 11 localhost 26Feb 12 23](https://user-images.githubusercontent.com/884482/75340444-cb72f680-5892-11ea-88f2-3f7548d6f532.png)
