### PR TITLE
Add documentation for wire:model loading state

### DIFF
--- a/source/docs/loading-states.blade.md
+++ b/source/docs/loading-states.blade.md
@@ -40,6 +40,18 @@ Now, when the "Checkout" button is clicked, the loading indicator will load, but
 
 Also note that `wire:target` can accept multiple arguments in a comma separated format like this: `wire:target="foo, bar"`.
 
+Besides actions you can also target whenever a `wire:model` is synchronized.
+
+@code(['lang' => 'html'])
+<div>
+    <input wire:model="quantity">
+
+    <div wire:loading wire:target="quantity">
+        Updating quantity...
+    </div>
+</div>
+@endcode
+
 ## Toggling classes {#toggling-classes}
 
 You can add or remove classes from an element during loading states, by adding the `.class` modifier to the `wire:loading` directive.


### PR DESCRIPTION
I'm not sure whether this is an officially supported feature :)

However from the current docs it wasn't clear that this is possible, I only found it trough trying. If this functionality is intended it would be great to have it in the docs.