### PR TITLE
Correct the default polling interval

### DIFF
--- a/source/docs/polling.blade.md
+++ b/source/docs/polling.blade.md
@@ -4,7 +4,7 @@ extends: _layouts.documentation
 section: content
 ---
 
-Livewire offers a directive called `wire:poll` that, when added to an element, will refresh the component every `5s`.
+Livewire offers a directive called `wire:poll` that, when added to an element, will refresh the component every `2s`.
 
 @tip
 Polling for changes over Ajax is a lightweight, simpler alternative to something like Laravel Echo, Pusher, or any WebSocket strategy.


### PR DESCRIPTION
According to the source code https://github.com/livewire/livewire/blob/a2789a7aa594681e3493ee92449b47b3605e9418/js/component/Polling.js#L26

the default polling interval is 2 seconds