### PR TITLE
Add colon for second parameter

### DIFF
--- a/source/docs/mount-method.blade.md
+++ b/source/docs/mount-method.blade.md
@@ -55,7 +55,7 @@ You can pass multiple parameters to the `mount()` hook and receive them as addit
 
 @code(['lang' => 'html'])
 @verbatim
-<livewire:show-contact :contact="$contact" section-heading="Show Contact">
+<livewire:show-contact :contact="$contact" :section-heading="Show Contact">
 @endverbatim
 @endcode
 


### PR DESCRIPTION
I couldn't try this on Laravel 7, but I guess the colon is missing in the second parameter