### PR TITLE
Added a tip about having a single root element

### DIFF
--- a/resources/views/docs/properties.blade.php
+++ b/resources/views/docs/properties.blade.php
@@ -149,6 +149,7 @@ Internally, Livewire will listen for an `input` event on the element, and when t
 
 @component('components.tip')
 You can add <code>wire:model</code> to any element that dispataches an <code>input</code> event. Even custom elements, or third-party JavaScript libraries.
+If you are using data binding in more than one element, be sure to wrap them with a single root element. Otherwise, data binding would work only for the first element.
 @endcomponent
 
 Common elements to use `wire:model` on include:


### PR DESCRIPTION
If there are more than one element that uses wire:model in a livewire component,  <code>wire:id</code> attribute is added only to the first/root element. I didn't have a root element in my component and ended up spending 2 hours trying to find why the data binding in the second element wouldn't work. Even though the mistake looks obvious, it wasn't mentioned anywhere in the documentation. This might help others in such situations.

Thank you for your awesome framework. I'm really enjoying this.