### PR TITLE
Remove duplication from nested component page

### DIFF
--- a/resources/views/docs/nesting-components.blade.php
+++ b/resources/views/docs/nesting-components.blade.php
@@ -56,9 +56,6 @@ Similar to VueJs, if you render a component inside a loop, Livewire has no way o
 <div>
     @foreach ($users as $user)
         @livewire('user-profile', $user, key($user->id))
-
-        <!-- key() using Laravel 7's tag syntax -->
-        <livewire:user-profile :user="$user" :key="$user->id">
     @endforeach
 </div>
 @endverbatim


### PR DESCRIPTION
The Laravel 7 tag syntax is mentioned right in the next paragraph, so this one seems to be unnecessary and duplicate.