### PR TITLE
Update properties.blade.php

### DIFF
--- a/resources/views/docs/properties.blade.php
+++ b/resources/views/docs/properties.blade.php
@@ -268,8 +268,8 @@ class SearchPosts extends Component
 
     protected $updatesQueryString = [
         'foo',
-        ['search' => ['except' => '']],
-        ['page' => ['except' => 1]],
+        'search' => ['except' => ''],
+        'page' => ['except' => 1],
     ];
 
     public function mount()


### PR DESCRIPTION
I might be wrong, but I think this is the right syntax to use `except` in the `$updatesQueryString` property.