### PR TITLE
Change name to title in testing.

### DIFF
--- a/resources/views/docs/testing.blade.php
+++ b/resources/views/docs/testing.blade.php
@@ -72,14 +72,14 @@ class CreatePostTest extends TestCase
     }
 
     /** @test */
-    function name_is_required()
+    function title_is_required()
     {
         $this->actingAs(factory(User::class)->create())
 
         Livewire::test(CreatePost::class)
             ->set('title', '')
             ->call('create')
-            ->assertHasErrors(['name' => 'required']);
+            ->assertHasErrors(['title' => 'required']);
     }
 
     /** @test */


### PR DESCRIPTION
In [testing](https://laravel-livewire.com/docs/testing) example, post does not have a `name`, it has a `title`.