### PR TITLE
Correct minor grammar issue in installation instructions

### DIFF
--- a/resources/views/docs/installation.blade.php
+++ b/resources/views/docs/installation.blade.php
@@ -50,7 +50,7 @@ php artisan vendor:publish --tag=livewire:config
 
 ## Configuring The Asset Base URL
 
-By default, Livewire serves it's JavaScript portion (`livewire.js`) from the following route in your app: `/livewire/livewire.js`.
+By default, Livewire serves its JavaScript portion (`livewire.js`) from the following route in your app: `/livewire/livewire.js`.
 
 The actual script tag that gets generated defaults to: `<script src="/livewire/livewire.js"`.
 


### PR DESCRIPTION
### Explanation
- `its` -> possessive, the JS portion in this sentence belongs to Livewire
- `it's` -> shorter version of `it is`