### PR TITLE
Fix comment

### DIFF
--- a/resources/views/docs/making-components.blade.php
+++ b/resources/views/docs/making-components.blade.php
@@ -15,7 +15,7 @@ php artisan make:livewire foo.bar
 # Creates Foo/Bar.php & foo/bar.blade.php
 
 php artisan make:livewire foo --inline
-# Creates only Foo/Bar.php
+# Creates only Foo.php
 @endcomponent
 
 Once created, you can render your components in a Blade file with the `@livewire('component-name')` blade directive.


### PR DESCRIPTION
Fix comment because `make:livewire foo` generates a `Foo.php` instead of `Foo/Bar.php`.