### PR TITLE
[UI] Make entire line clickable in screencast sidebar menu

### DIFF
--- a/resources/views/includes/screencast-sidebar.blade.php
+++ b/resources/views/includes/screencast-sidebar.blade.php
@@ -5,12 +5,12 @@
             <h5 class="text-lg font-semibold text-blue-800">{{ $series->title }}</h5>
             <ul class="list-none">
                 @foreach ($series->screencasts as $screencast)
-                    <li class="flex justify-between items-center mb-1 rounded-full -mx-1 p-1 pr-2 hover:bg-gray-100 {{ $screencast->is($activeScreencast ?? null) ? 'bg-indigo-500 hover:bg-indigo-500 text-white' : '' }}">
-                        <div class="flex items-center">
-                            <a href="/screencasts/{{ $screencast->slug }}" style="width: 1.75rem" class="mr-2 rounded-full  {{ $screencast->is($activeScreencast ?? null) ? ' bg-transparent text-white hover:text-white cursor-default' : ' text-indigo-600 hover:text-indigo-700 bg-indigo-100 hover:bg-indigo-200' }}">{!! file_get_contents(public_path($screencast->is($activeScreencast ?? null) ? '/img/three-dots.svg' : '/img/play-button-circle.svg')) !!}</a>
-                            <a href="/screencasts/{{ $screencast->slug }}" class="text-xs font-semibold {{ $screencast->is($activeScreencast ?? null) ? 'text-white hover:text-indigo-100' : '' }}">{{ $screencast->title }}</a>
-                        </div>
-                        <span class="text-xs font-bold {{ $screencast->is($activeScreencast ?? null) ? 'text-white' : 'text-gray-500' }}">{{ $screencast->duration_in_minutes }}</span>
+                    <li>
+                        <a href="/screencasts/{{ $screencast->slug }}" class="flex justify-start items-center mb-1 rounded-full -mx-1 p-1 pr-2 hover:bg-gray-100 {{ $screencast->is($activeScreencast ?? null) ? 'bg-indigo-500 hover:bg-indigo-500 text-white' : '' }}">
+                            <span style="width: 1.75rem" class="mr-2 rounded-full  {{ $screencast->is($activeScreencast ?? null) ? ' bg-transparent text-white hover:text-white cursor-default' : ' text-indigo-600 hover:text-indigo-700 bg-indigo-100 hover:bg-indigo-200' }}">{!! file_get_contents(public_path($screencast->is($activeScreencast ?? null) ? '/img/three-dots.svg' : '/img/play-button-circle.svg')) !!}</span>
+                            <span class="text-xs font-semibold {{ $screencast->is($activeScreencast ?? null) ? 'text-white hover:text-indigo-100' : '' }}">{{ $screencast->title }}</span>
+                            <span class="text-xs font-bold ml-auto {{ $screencast->is($activeScreencast ?? null) ? 'text-white' : 'text-gray-500' }}">{{ $screencast->duration_in_minutes }}</span>
+                        </a>
                     </li>
                 @endforeach
             </ul>


### PR DESCRIPTION
What it says on the tin, you can now click the sidebar link even between the scrrencast title and its duration. Or even on the duration.

![image](https://user-images.githubusercontent.com/3909549/80828394-7f6f6580-8be5-11ea-96a8-898d5782cdda.png)
