### PR TITLE
Add missing test facilities

### DIFF
--- a/resources/views/docs/testing.blade.php
+++ b/resources/views/docs/testing.blade.php
@@ -123,10 +123,10 @@ Livewire::actingAs($user);
 // Asserts that the "foo" property is NOT set to the value "bar"
 
 ->assertSee('foo');
-// Assert that the string "foo" exists in the currently rendered HTML of the component
+// Assert that the string "foo" exists in the currently rendered content of the component
 
 ->assertDontSee('foo');
-// Assert that the string "foo" DOES NOT exist in the HTML
+// Assert that the string "foo" DOES NOT exist in the currently rendered content of the component
 
 ->assertSeeHtml('<h1>foo</h1>');
 // Assert that the string "<h1>foo</h1>" exists in the currently rendered HTML of the component

--- a/resources/views/docs/testing.blade.php
+++ b/resources/views/docs/testing.blade.php
@@ -128,6 +128,9 @@ Livewire::actingAs($user);
 ->assertDontSee('foo');
 // Assert that the string "foo" DOES NOT exist in the HTML
 
+->assertSeeHtml('<h1>foo</h1>');
+// Assert that the string "<h1>foo</h1>" exists in the currently rendered HTML of the component
+
 ->assertEmitted('foo');
 // Assert that the "foo" event was emitted
 

--- a/resources/views/docs/testing.blade.php
+++ b/resources/views/docs/testing.blade.php
@@ -131,6 +131,9 @@ Livewire::actingAs($user);
 ->assertSeeHtml('<h1>foo</h1>');
 // Assert that the string "<h1>foo</h1>" exists in the currently rendered HTML of the component
 
+->assertDontSeeHtml('<h1>foo</h1>');
+// Assert that the string "<h1>foo</h1>" DOES NOT exist in the currently rendered HTML of the component
+
 ->assertEmitted('foo');
 // Assert that the "foo" event was emitted
 

--- a/resources/views/docs/testing.blade.php
+++ b/resources/views/docs/testing.blade.php
@@ -95,6 +95,21 @@ class CreatePostTest extends TestCase
 }
 @endcomponent
 
+## Testing Component Presence {#testing-component-presence}
+
+Livewire registers a handy PHPUnit method to test for a component's presence on a page.
+
+@component('components.code', ['lang' => 'php'])
+class CreatePostTest extends TestCase
+{
+    /** @test */
+    function post_creation_page_contains_livewire_component()
+    {
+        $this->get('/posts/create')->assertSeeLivewire('create-post');
+    }
+}
+@endcomponent
+
 ## All Available Test Methods {#all-testing-methods}
 
 @component('components.code', ['lang' => 'php'])

--- a/resources/views/docs/testing.blade.php
+++ b/resources/views/docs/testing.blade.php
@@ -99,7 +99,7 @@ class CreatePostTest extends TestCase
 
 @component('components.code', ['lang' => 'php'])
 Livewire::actingAs($user);
-// Set the provided user as the session's logged in user for the test.
+// Set the provided user as the session's logged in user for the test
 
 ->set('foo', 'bar');
 // Set the "foo" property (`public $foo`) to the value: "bar"
@@ -162,7 +162,7 @@ Livewire::actingAs($user);
 // Assert that an error within the component caused an error with the status code: 404
 
 ->assertRedirect('/some-path');
-// Assert that a redirect was triggered from the component.
+// Assert that a redirect was triggered from the component
 
 ->assertUnauthorized();
 // Assert that an error within the component caused an error with the status code: 401


### PR DESCRIPTION
- `assertSeeLivewire()` - checks for component presence on a page.
- `assertSeeHtml()` - checks for presence of raw HTML.
- `assertDontSeeHtml()` - checks for absence of raw HTML.