### PR TITLE
Update nesting-components

### DIFF
--- a/resources/views/docs/nesting-components.blade.php
+++ b/resources/views/docs/nesting-components.blade.php
@@ -75,3 +75,23 @@ If you are on Laravel 7 or above, you can use the tag syntax.
 @endverbatim
 @endslot
 @endcomponent
+
+### Sibling Components in a Loop
+
+In some situations, you may find the need to have sibling components inside of a loop, this situation reqires additional consideration for the `key` value.
+
+Each component will need its own `key` directive, using the method above will lead to both sibling components having the same key, which will cause unforeseen issues.  The solution is to ensure that each sibling component has a truly unique key, one possible technique is to multiply the ID of the model by a random integer, for example:
+
+```php
+// user-profile component
+<div>    
+    // Bad
+    <livewire:user-profile-additional-component :user="$user" :key="$user->id">
+    <livewire:user-profile-some-related-component :user="$user" :key="$user->id">
+    
+    // Good
+    <livewire:user-profile-additional-component :user="$user" :key="(rand() * $user->id)">
+    <livewire:user-profile-some-related-component :user="$user" :key="(rand() * $user->id)">
+</div>
+```
+

--- a/resources/views/docs/nesting-components.blade.php
+++ b/resources/views/docs/nesting-components.blade.php
@@ -82,8 +82,9 @@ In some situations, you may find the need to have sibling components inside of a
 
 Each component will need its own `key` directive, using the method above will lead to both sibling components having the same key, which will cause unforeseen issues.  The solution is to ensure that each sibling component has a truly unique key, one possible technique is to multiply the ID of the model by a random integer, for example:
 
-```php
-// user-profile component
+@component('components.code', ['lang' => 'html'])
+@verbatim
+<!-- user-profile component -->
 <div>    
     // Bad
     <livewire:user-profile-additional-component :user="$user" :key="$user->id">
@@ -93,5 +94,5 @@ Each component will need its own `key` directive, using the method above will le
     <livewire:user-profile-additional-component :user="$user" :key="(rand() * $user->id)">
     <livewire:user-profile-some-related-component :user="$user" :key="(rand() * $user->id)">
 </div>
-```
-
+@endverbatim
+@endcomponent


### PR DESCRIPTION
I struggled to determine why morphdom kept having issues when I had two sibling components inside a loop, it kept incorrectly patching the DOM and throwing `Cannot read property 'data' of null` errors at me. I eventually realized I was given each sibling component the same key, namely the model ID as suggested, but that lead to two components having the same value for what was supposed to be the unique identifier. 

I found the solution in an issue on the `livewire/livewire` repo, and it works great, this is simply documentation for that situation. Let me know if you think the wording can be improved in any way.

Related Issue: https://github.com/livewire/livewire/issues/659 

Cheers Caleb 🙂