### PR TITLE
Update resources/views/docs/polling.blade.php

### DIFF
--- a/resources/views/docs/polling.blade.php
+++ b/resources/views/docs/polling.blade.php
@@ -33,8 +33,9 @@ You can also specify a specific action to fire on the polling interval by passin
 @endverbatim
 @endcomponent
 
-Now, the `foo` method on the component will be called every 5 seconds.
+Now, the `foo` method on the component will be called every 2 seconds.
 
 @component('components.tip')
 Livewire reduces polling when the browser tab is in the background so that it doesn't bog down the server with ajax requests unnecessarily.
+Only about 5% of the expected polling requests are kept.
 @endcomponent


### PR DESCRIPTION
Fixes a minor documentation issue (polling interval is 2 instead of 5 seconds) and adds a hint about the amount of polling requests performed for minimized browser tabs.

Code snippet for polling interval:
https://github.com/livewire/livewire/blob/b0eb63ac7419be230013b67c0b724478ddf76aa4/js/component/Polling.js#L39

Code snippet for heuristics of background operations:
https://github.com/livewire/livewire/blob/b0eb63ac7419be230013b67c0b724478ddf76aa4/js/component/Polling.js#L52-L55