### PR TITLE
Add note to Properties page about not currently supporting PHP typed properties

### DIFF
--- a/resources/views/docs/properties.blade.php
+++ b/resources/views/docs/properties.blade.php
@@ -63,6 +63,7 @@ Here are three ESSENTIAL things to note about public properties before embarking
 
 1. Data stored in public properties is made visible to the front-end JavaScript. Therefore, you SHOULD NOT store sensitive data in them.
 2. Properties can ONLY be either a JavaScript-friendly data types (`string`, `int`, `array`, `boolean`), OR an eloquent model (or collection of models).
+3. **For PHP >= 7.4 users:** public properties in Livewire components DO NOT currently support typed properties.
 
 @component('components.warning')
 <code>protected</code> and <code>private</code> properties DO NOT persist between Livewire updates. In general, you should avoid using them for storing state.


### PR DESCRIPTION
Currently, Livewire doesn't support PHP typed properties (in the language since [PHP 7.4](https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.typed-properties)), but there isn't a note about that on the "Properties" page of the docs. This PR adds that note.

Also noticed that there must have used to be three important notes, because the section said "here are _three_ ESSENTIAL things...", so no change had to be made there!

I tried to capture the current feel of the documentation that's around this new note, but I'm open to discussion if something feels off about it!