### PR TITLE
Only test podcasts if the env variable for SIMPLECAST_API_KEY is set

### DIFF
--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -28,10 +28,13 @@ class RoutesTest extends TestCase
             $this->get('/docs/'.$slug)->assertSuccessful();
         });
 
-        // Podcasts
-        $this->get('/podcast')->assertSuccessful();
-        PodcastEpisode::all()->each(function ($podcast) {
-            $this->get('/podcasts/'.$podcast->filename)->assertSuccessful();
-        });
+        if(env('SIMPLECAST_API_KEY')){
+            // Podcasts
+            $this->get('/podcast')->assertSuccessful();
+            PodcastEpisode::all()->each(function ($podcast) {
+                $this->get('/podcasts/'.$podcast->filename)->assertSuccessful();
+            });
+        }
+
     }
 }

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -28,13 +28,12 @@ class RoutesTest extends TestCase
             $this->get('/docs/'.$slug)->assertSuccessful();
         });
 
-        if(env('SIMPLECAST_API_KEY')){
+        if (env('SIMPLECAST_API_KEY')) {
             // Podcasts
             $this->get('/podcast')->assertSuccessful();
             PodcastEpisode::all()->each(function ($podcast) {
                 $this->get('/podcasts/'.$podcast->filename)->assertSuccessful();
             });
         }
-
     }
 }


### PR DESCRIPTION
Currently every PR is failing tests due to missing SIMPLECAST_API_KEY

Unless we add a test simplecast account and key or imitate proper response with a list of podcasts, this will always fail.

So i propose we skip this assertion unless the key is set, this way @calebporzio can still test it in his local environment where he probably has the SIMPLECAST_API_KEY set.