### PR TITLE
Initiate custom cast properties to avoid exceptions

### DIFF
--- a/resources/views/docs/properties.blade.php
+++ b/resources/views/docs/properties.blade.php
@@ -308,15 +308,22 @@ Livewire offers an api to "cast" public properties to a more usable data type. T
 @verbatim
 class CastedComponent extends Component
 {
-    public $options = ['foo', 'bar', 'bar'];
-    public $expiresAt = 'tomorrow';
-    public $formattedDate = 'today';
+    public $options;
+    public $expiresAt;
+    public $formattedDate;
 
     protected $casts = [
         'options' => 'collection',
         'expiresAt' => 'date',
         'formattedDate' => 'date:m-d-y'
     ];
+    
+    public function mount()
+    {
+        $this->options = collect(['foo', 'bar', 'bar']);
+        $this->expiresAt = \Carbon\Carbon::parse('tomorrow');
+        $this->formattedDate = \Carbon\Carbon::parse('today');
+    }
 
     public function getUniqueOptions()
     {


### PR DESCRIPTION
If the public properties are set to the "uncast" versions, we get exceptions when trying to uncast an uncasted value. 

For example when setting a field to cast as collection we get `Call to a member function toArray() on array`