### PR TITLE
Fix Example In Pagination

### DIFF
--- a/resources/views/docs/pagination.blade.php
+++ b/resources/views/docs/pagination.blade.php
@@ -66,7 +66,7 @@ class ShowPosts extends Component
 {
     use WithPagination;
 
-    public $search = ;
+    public $search = '';
 
     public function updatingSearch()
     {


### PR DESCRIPTION
The public property $search currently returns an error as no assignment.