### PR TITLE
Adds documentation for filling using an eloquent model.

### DIFF
--- a/resources/views/docs/properties.blade.php
+++ b/resources/views/docs/properties.blade.php
@@ -105,6 +105,18 @@ public function mount()
 @endslot
 @endcomponent
 
+You can even pass `$this->fill()` an Eloquent model. When you do, public properties in your Livewire component that match properties included in your Eloquent model's `toArray()` method
+will be filled.
+
+@component('components.code-component', ['className' => 'HelloWorld.php'])
+@slot('class')
+public function mount(User $user)
+{
+    $this->fill($user);
+}
+@endslot
+@endcomponent
+
 Additionally, Livewire offers `$this->reset()` to programatically reset public property values to their initial state. This is useful for cleaning input fields after performing an action.
 
 @component('components.code')Component


### PR DESCRIPTION
Currently, the documentation only provides information on using an associative array with the `fill` method. This adds documentation and a code example on using an Eloquent model with the `fill` method. 