### PR TITLE
Adds the missing Inline Scripts page inside JS Integrations

### DIFF
--- a/app/DocumentationPages.php
+++ b/app/DocumentationPages.php
@@ -36,6 +36,7 @@ class DocumentationPages
             'AlpineJS' => 'alpine-js',
             'Turbolinks' => 'turbolinks',
             'Laravel Echo' => 'laravel-echo',
+            'Inline Scripts' => 'inline-scripts',
         ],
         'Testing' => 'testing',
         'Security' => 'security',


### PR DESCRIPTION
The Inline Scripts page is missing form the menu. I added it inside the JS Integration but can be changed as you see fit.