### PR TITLE
Clear error bag when using custom validators

### DIFF
--- a/resources/views/docs/2/input-validation.blade.php
+++ b/resources/views/docs/2/input-validation.blade.php
@@ -234,11 +234,15 @@ class ContactForm extends Component
 
     public function saveContact()
     {
-        $validatedData = Validator::make(
+        $validator = Validator::make(
             ['email' => $this->email],
             ['email' => 'required|email'],
             ['required' => 'The :attribute field is required'],
-        )->validate();
+        );
+
+        $this->resetErrorBag();
+
+        $validatedData = $validator->validate();
 
         Contact::create($validatedData);
     }


### PR DESCRIPTION
@danharrin See my convo with Ryan here https://discordapp.com/channels/698229985755791471/698231501501890600/753315724751143052

Although, this makes more sense when using validation in `updated()`. I guess it still makes sense here though, since the method will fail halfway and make the error bag dirty.