### PR TITLE
Add query string troubleshooting section

### DIFF
--- a/resources/views/docs/2/troubleshooting.blade.php
+++ b/resources/views/docs/2/troubleshooting.blade.php
@@ -73,3 +73,16 @@ class HelloWorld extends Component
     ...
 @endverbatim
 @endcomponent
+
+## Query String Issues
+
+Livewire is using the site's `referrer` information when setting the query string. This can lead to conflicts when you are adding security headers to your application through the `referrer-policy`.
+
+### Symptoms:
+
+* The query string does not get updated at all.
+* The query string does not get updated when the value is empty.
+
+### Cures:
+
+If you do set security headers, make sure the `referrer-policy` value is set to `same-origin`.


### PR DESCRIPTION
I've had encountered problems with the `query string` feature of Livewire on my blog. @nuernbergerA helped me to backtrace it to the `security headers` which I set in my application.

The `referrer-policy` is the one that caused the problem. It needs to be set to `same-origin` to make it work with Livewire's query string.

I thought it might be a good idea to add that information to the docs.