### PR TITLE
Fix typo in v2 nesting components

### DIFF
--- a/resources/views/docs/2/nesting-components.blade.php
+++ b/resources/views/docs/2/nesting-components.blade.php
@@ -63,7 +63,7 @@ If you are on Laravel 7 or above, you can use the tag syntax.
 
 ### Sibling Components in a Loop
 
-In some situations, you may find the need to have sibling components inside of a loop, this situation reqires additional consideration for the `key` value.
+In some situations, you may find the need to have sibling components inside of a loop, this situation requires additional consideration for the `key` value.
 
 Each component will need its own unique `key`, but using the method above will lead to both sibling components having the same key, which will cause unforeseen issues. To combat this, you could ensure that each `key` is unique by prefixing it with the component name, for example:
 


### PR DESCRIPTION
Fixed typo in Nesting Components - https://laravel-livewire.com/docs/2.x/nesting-components

`reqires` updated to `requires`