### PR TITLE
Document wire:poll.keep-alive and $validationAttributes

### DIFF
--- a/resources/views/docs/1/input-validation.blade.php
+++ b/resources/views/docs/1/input-validation.blade.php
@@ -145,7 +145,7 @@ $this->addError('email', 'The email field is invalid.');
 
 $this->resetErrorBag();
 $this->resetValidation();
-// These two methods do the same thing. The clear the error bag.
+// These two methods do the same thing. They clear the error bag.
 // If you only want to clear errors for one key, you can use:
 $this->resetValidation('email');
 $this->resetErrorBag('email');

--- a/resources/views/docs/1/nesting-components.blade.php
+++ b/resources/views/docs/1/nesting-components.blade.php
@@ -78,7 +78,7 @@ If you are on Laravel 7 or above, you can use the tag syntax.
 
 ### Sibling Components in a Loop
 
-In some situations, you may find the need to have sibling components inside of a loop, this situation reqires additional consideration for the `key` value.
+In some situations, you may find the need to have sibling components inside of a loop, this situation requires additional consideration for the `key` value.
 
 Each component will need its own unique `key`, but using the method above will lead to both sibling components having the same key, which will cause unforeseen issues. To combat this, you could ensure that each `key` is unique by prefixing it with the component name, for example:
 

--- a/resources/views/docs/2/input-validation.blade.php
+++ b/resources/views/docs/2/input-validation.blade.php
@@ -146,7 +146,9 @@ class ContactForm extends Component
 
 ## Customize Error Message & Attributes
 
-If you wish to customize the validation messages used by a Livewire component, you can do so with the `$messages` property:
+If you wish to customize the validation messages used by a Livewire component, you can do so with the `$messages` property. 
+
+If you want to keep the default Laravel validation messages, but just customize the `:attribute` portion of the message, you can specify custom attribute names using the `$validationAttributes` property. 
 
 @component('components.code-component')
 @slot('class')
@@ -162,6 +164,10 @@ class ContactForm extends Component
     protected $messages = [
         'email.required' => 'The Email Address cannot be empty.',
         'email.email' => 'The Email Address format is not valid.',
+    ];
+
+    protected $validationAttributes = [
+        'email' => 'email address'
     ];
 
     public function updated($propertyName)

--- a/resources/views/docs/2/polling.blade.php
+++ b/resources/views/docs/2/polling.blade.php
@@ -35,7 +35,18 @@ You can also specify a specific action to fire on the polling interval by passin
 
 Now, the `foo` method on the component will be called every 2 seconds.
 
-@component('components.tip')
+
+## Polling in the background
+
 Livewire reduces polling when the browser tab is in the background so that it doesn't bog down the server with ajax requests unnecessarily.
 Only about 5% of the expected polling requests are kept.
+
+If you'd like to keep polling at the normal rate even while the tab is in the background, you can use the `keep-alive` modifier: 
+
+@component('components.code')
+@verbatim
+<div wire:poll.keep-alive>
+    Current time: {{ now() }}
+</div>
+@endverbatim
 @endcomponent


### PR DESCRIPTION
I noticed that a couple new features since v2 haven't been documented, and wanted to add them to the docs so people who don't follow the project as closely can take advantage of them too. 

Let me know if there's a better way to explain any of these things! 