### PR TITLE
Add message to placeholder in search input

### DIFF
--- a/resources/views/includes/search-input.blade.php
+++ b/resources/views/includes/search-input.blade.php
@@ -17,7 +17,7 @@
         style="transition: width .2s;"
         name="docsearch"
         type="text"
-        placeholder="Search"
+        placeholder='Search the docs (Press "/" to focus)'
     >
 
     <button


### PR DESCRIPTION
I was looking at #233 and noticed that this feature is actually already added, but there is no indication to the user. I updated the placeholder in the search input to the same wording as the Tailwind docs: Search the docs (Press "/" to focus)