### PR TITLE
Don't new up a Vimeo player when the video isn't shown

### DIFF
--- a/resources/views/livewire/screencast-player.blade.php
+++ b/resources/views/livewire/screencast-player.blade.php
@@ -69,6 +69,11 @@
         return {
             init() {
                 var iframe = document.querySelector('iframe');
+
+                if (!iframe) {
+                    return;
+                }
+
                 var player = new Vimeo.Player(iframe);
 
                 if (localStorage.getItem('livewire.screencasts.rate')) {


### PR DESCRIPTION
This PR fixes these errors when a user isn't a sponsor and tries to view a sponsor-only video.

![image](https://user-images.githubusercontent.com/25065083/96898354-9e94d480-145d-11eb-95e6-023d0b2a69ed.png)
