### PR TITLE
Add Algolia docs versioning

### DIFF
--- a/resources/views/includes/search-input.blade.php
+++ b/resources/views/includes/search-input.blade.php
@@ -34,7 +34,10 @@
                 apiKey: '{{ $docsearchApiKey }}',
                 indexName: '{{ $docsearchIndexName }}',
                 inputSelector: '#docsearch-input',
-                debug: false // Set debug to true if you want to inspect the dropdown
+                debug: false, // Set debug to true if you want to inspect the dropdown
+                algoliaOptions: {
+                    facetFilters: ["version:{{ (new \App\DocumentationPages())->newestVersion() }}.x"]
+                },
             });
 
             const searchInput = {

--- a/resources/views/layouts/documentation.blade.php
+++ b/resources/views/layouts/documentation.blade.php
@@ -4,6 +4,9 @@
     @unless($pages->isNewestVersion())
         <link rel="canonical" href="{{ secure_url('docs/'.$pages->newestVersion().'.x/'.$pages->currentPage) }}" />
     @endunless
+
+    <meta name="docsearch:language" content="en" />
+    <meta name="docsearch:version" content="{{ $versionSlug }}" />
 @endpush
 
 @section('nav-menu')

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,7 @@ Route::get('/docs/{versionSlug}/{pageSlug}', function ($versionSlug, $pageSlug) 
         'social_image' => ($versionSlug === '2.x' && $pageSlug === 'upgrading') ? 'https://laravel-livewire.com/img/twitter-card2.jpg' : 'https://laravel-livewire.com/img/twitter.png',
         'title' => $pages->title(),
         'slug' => $pageSlug,
+        'versionSlug' => $versionSlug,
         'pages' => $pages,
         'content' => $content,
     ]);


### PR DESCRIPTION
This will make the docsearch input only show results from V2 instead of showing duplicate entries from V1 and V2.

I've submitted a PR to update the Algolia configuration [here](https://github.com/algolia/docsearch-configs/pull/2652), but it seems to be working already.