### PR TITLE
Remove option when publishing config file

### DIFF
--- a/installation.blade.php
+++ b/installation.blade.php
@@ -44,7 +44,7 @@ You can publish Livewire's config file with the following artisan command:
 
 @component('components.code', ['lang' => 'bash'])
 @verbatim
-php artisan livewire:publish --config
+php artisan livewire:publish
 @endverbatim
 @endcomponent
 


### PR DESCRIPTION
- The option `config` isn't available

![image](https://user-images.githubusercontent.com/6760803/99420451-d6f3cb00-28c2-11eb-8485-c1b10f6a5874.png)
