### PR TITLE
Fix sort  direction logical issue

### DIFF
--- a/traits.blade.php
+++ b/traits.blade.php
@@ -14,11 +14,11 @@ class ShowPosts extends Component
 
     public function sortBy($field)
     {
-        $this->sortBy = $field;
-
         $this->sortDirection = $this->sortBy === $field
             ? $this->reverseSort()
             : 'asc';
+
+        $this->sortBy = $field;
     }
 
     public function reverseSort()

--- a/traits.blade.php
+++ b/traits.blade.php
@@ -59,11 +59,11 @@ trait WithSorting
 
     public function sortBy($field)
     {
-        $this->sortBy = $field;
-
         $this->sortDirection = $this->sortBy === $field
             ? $this->reverseSort();
             : 'asc';
+
+        $this->sortBy = $field;
     }
 
     public function reverseSort()


### PR DESCRIPTION
sortBy should only be reassigned after the direction is determined else you'll always just be reversing