### PR TITLE
Fix "Scoping To Parent Listeners" heading level.

### DIFF
--- a/events.blade.php
+++ b/events.blade.php
@@ -112,7 +112,7 @@ class ShowPosts extends Component
 
 ## Scoping Events {#scoping-events}
 
-## Scoping To Parent Listeners {#scope-to-parents}
+### Scoping To Parent Listeners {#scope-to-parents}
 When dealing with [nested components](nesting-components), sometimes you may only want to emit events to parents and not children or sibling components.
 
 In these cases, you can use the `emitUp` feature:


### PR DESCRIPTION
Hello there.&nbsp; 👋

I was reading the documentation and noticed the `Scoping To Parent Listeners` subheading was a level too high.

This PR aims to fix that issue by downgrading the heading one level down to an `h3`.
I've included screenshots of the issue and the potential fix. 🙂

## Screenshot of issue.

![Screen shot of headings](https://user-images.githubusercontent.com/2221746/99764657-d3985380-2afd-11eb-9843-7401c9f6b4ef.png)

## Screenshot of PR fix.

![Screen shot of headings being fixed](https://user-images.githubusercontent.com/2221746/99764750-04788880-2afe-11eb-9307-122afaa96c78.png)
