### PR TITLE
Add missing $this variable in front of `->validate()` inline code block.

### DIFF
--- a/input-validation.blade.php
+++ b/input-validation.blade.php
@@ -1,5 +1,5 @@
 
-Validation in Livewire should feel similar to standard form validation in Laravel. In short, Livewire provides a `$rules` property for setting validation rules on a per-component basis, and a `->validate()` method for validating a component's properties using those rules.
+Validation in Livewire should feel similar to standard form validation in Laravel. In short, Livewire provides a `$rules` property for setting validation rules on a per-component basis, and a `$this->validate()` method for validating a component's properties using those rules.
 
 Here's a simple example of a form in Livewire being validated.
 


### PR DESCRIPTION
Hi again.&nbsp; 👋

While browsing the documentation I found a typo in the starting paragraph under the **Validation**  section.
This PR fixes remedies that by adding a missing `$this` in front of that inline code block.
With this PR it will match the inline code block inside the first paragraph after **Real-time Validation**.

![Screen shot of real-time validation paragraph](https://user-images.githubusercontent.com/2221746/99766843-355abc80-2b02-11eb-995f-6f14afebfc79.png)


### Screenshot of issue.

![Screen shot of validation paragraph with missing this variable](https://user-images.githubusercontent.com/2221746/99766475-78686000-2b01-11eb-8dd6-b1dbc08f0f95.png)

### Screenshot of PR fix.

![Screen shot of validation paragraph with this variable added in front of inline code block](https://user-images.githubusercontent.com/2221746/99766491-80280480-2b01-11eb-85d0-ce995145b58d.png)
