### PR TITLE
--config option does not exist

### DIFF
--- a/installation.blade.php
+++ b/installation.blade.php
@@ -44,7 +44,7 @@ You can publish Livewire's config file with the following artisan command:
 
 @component('components.code', ['lang' => 'bash'])
 @verbatim
-php artisan livewire:publish --config
+php artisan livewire:publish
 @endverbatim
 @endcomponent
 


### PR DESCRIPTION
When running `php artisan livewire:publish --config` you get:

>  The "--config" option does not exist.

Running `php artisan livewire:publish` creates the config/livewire.php file.