### PR TITLE
Fix typo in "Accessing Livewire Directives From Blade Components" section.

### DIFF
--- a/alpine-js.blade.php
+++ b/alpine-js.blade.php
@@ -241,7 +241,7 @@ For example, you might create a text input Blade component like so:
 
 A simple Blade component like this will work perfectly fine. Laravel and Blade will automatically forward any extra attributes added to the component (like `wire:model` in this case), and place them on the `<input>` tag because we echoed out the attribute bag (`$attributes`).
 
-However, sometimes you might need to extract more detailed into about Livewire attributes passed to the component.
+However, sometimes you might need to extract more detailed information about Livewire attributes passed to the component.
 
 For these cases, Livewire offers a `$attributes->wire()` method to help with these tasks.
 


### PR DESCRIPTION
Me again. 😀

Found a typo while reading about using **AlpineJS** with **Livewire**, thought I'd submit a PR for it.

### Screenshot of the typo.

![Screenshot of the typo](https://user-images.githubusercontent.com/2221746/99890616-8c2ad800-2c61-11eb-95de-b18ca37c564d.png)

### Screenshot of PR fix.

![Screenshot of PR fix](https://user-images.githubusercontent.com/2221746/99890619-8fbe5f00-2c61-11eb-80c4-222ebe566136.png)
