### PR TITLE
Adds documentation on using test helpers in packages

### DIFF
--- a/package-dev.blade.php
+++ b/package-dev.blade.php
@@ -22,3 +22,44 @@ Now, applications with your package installed can consume your component in thei
 </div>
 @endverbatim
 @endcomponent
+
+## Testing Components
+
+You may wish to write tests that use the `Livewire::test` helper in your package. Out of the box, this won't work
+because Livewire won't be able to find your components. Don't worry, you can fix this in two simple steps.
+
+### Tell Livewire where to find your package views
+
+First, we need to show Livewire how to find your package views. In any test that extends `Orchestra\Testbench\TestCase`,
+you can use the `getEnvironmentSetup` method for this.
+
+@component('components.code', ['lang' => 'php'])
+class MyLivewireTest extends Orchestra\Testbench\TestCase {
+    protected function getEnvironmentSetup($app)
+    {
+        $app['config']->set('view.paths', [__DIR__ . '/path/to/your/package/views']);
+    }
+}
+@endcomponent
+
+Your view directory should mirror a real application by including a `livewire` directory. All livewire views should be
+placed in there.
+
+### Tell Composer how to load your Components
+
+The second step is making Livewire think it's in a standard Laravel application. Composer allows us to do this using
+the `autoload-dev` entry in your `composer.json` file.
+
+@component('components.code', ['lang' => 'json'])
+"autoload-dev": {
+    "psr-4": {
+        "App\\Http\\Livewire\\": "path/to/your/livewire/components"
+    }
+}
+@endcomponent
+
+Its important that you use `autoload-dev` instead of `autoload` for this to ensure that you don't end up breaking
+namespacing in the Laravel application your package is installed in.
+
+The great thing about this approach is that it even works for Livewire Components that you will publish to the
+Laravel application.


### PR DESCRIPTION
Based on this tweet [https://twitter.com/LukeDowning19/status/1337459025127071745?s=20](https://twitter.com/LukeDowning19/status/1337459025127071745?s=20).

This update documents how to go about using Livewire test helpers in packages, so that you can unit test your package components without needing a separate project to install it into.