### PR TITLE
Property/model names cannot conflict with properties reserved for Livewire

### DIFF
--- a/properties.blade.php
+++ b/properties.blade.php
@@ -47,10 +47,11 @@ class HelloWorld extends Component
 
 ### Important Notes {#important-notes}
 
-Here are two ESSENTIAL things to note about public properties before embarking on your Livewire journey:
+Here are three ESSENTIAL things to note about public properties before embarking on your Livewire journey:
 
-1. Data stored in public properties is made visible to the front-end JavaScript. Therefore, you SHOULD NOT store sensitive data in them.
-2. Properties can ONLY be either JavaScript-friendly data types (`string`, `int`, `array`, `boolean`), OR one of the following PHP types: `Stringable`, `Collection`, `DateTime`, `Model`, `EloquentCollection`.
+1. Property names can't conflict with property names reserved for Livewire (e.g. `rules` or `messages`)
+2. Data stored in public properties is made visible to the front-end JavaScript. Therefore, you SHOULD NOT store sensitive data in them.
+3. Properties can ONLY be either JavaScript-friendly data types (`string`, `int`, `array`, `boolean`), OR one of the following PHP types: `Stringable`, `Collection`, `DateTime`, `Model`, `EloquentCollection`.
 
 @component('components.warning')
 <code>protected</code> and <code>private</code> properties DO NOT persist between Livewire updates. In general, you should avoid using them for storing state.


### PR DESCRIPTION
Added a new important note regarding Livewire properties.

I struggled with this a little while and didn't find out what the problem was until I started tracing the code in the vendor folder. I had a property/model that was not behaving as expected. I set a `messages` property which was a Collection of chat messages but Livewire was using it to set custom validation messages; but since the Validator factory requires the messages variable to be an array and my messages was a collection, it was giving me an error every time I tried to execute the `$this->validate()` function. 

It seems obvious in retrospect but I updated the Important Notes section to include this because it can be a gotcha. There also needs to be a single list we can refer to that includes all the properties we cannot use in a component.

Here is hopefully a complete list of reserved properties. I'm not sure how you want them in the docs but I do think it would be helpful to have a complete list somewhere:
```
computedPropertyCache
dispatchQueue
errorBag
eventQueue
id
initialLayoutConfiguration
listeners
messages
preRenderedView
previouslyRenderedChildren
queryString
redirectTo
renderedChildren
rules
shouldSkipRender
validationAttributes
```