### PR TITLE
Added tip to install vue-plugin during install.

### DIFF
--- a/installation.blade.php
+++ b/installation.blade.php
@@ -36,6 +36,10 @@ You can alternatively use the tag syntax.
 
 That's it! That's all you need to start using Livewire. Everything else on this page is optional.
 
+@component('components.tip')
+If you are using VueJS along with Livewire, you may need to add a small [vue-plugin](https://github.com/livewire/vue) to prevent certain "fingerprint" errors for nested components.
+@endcomponent
+
 ## Publishing The Config File {#publishing-config}
 
 Livewire aims for "zero-configuration" out-of-the-box, but some users require more configuration options.


### PR DESCRIPTION
Having this tip during installation would save a lot of time troubleshooting fingerprint errors. Personally I didn't know I needed this till I hit nested components and despite me trying to add keys to all my components as mentioned in the troubleshooting it was not resolved till I used the plugin.

The docs only mentions livewire-vue plugin in the upgrade from 1.x to 2.x. However this can be missed by someone who is directly entering the ecosystem from 2.x onwards like me.