### PR TITLE
Update lifecycle-hooks.blade.php

### DIFF
--- a/lifecycle-hooks.blade.php
+++ b/lifecycle-hooks.blade.php
@@ -50,12 +50,12 @@ class HelloWorld extends Component
         //
     }
 
-    public function updating($name, $value)
+    public function updating($value, $name)
     {
         //
     }
 
-    public function updated($name, $value)
+    public function updated($value, $name)
     {
         //
     }


### PR DESCRIPTION
updating and updated parameters are mis-labelled i.e. they are reversed in the docs.

Also, something I can't figure is how to use updatedFoo or updatedFooBar when the properties have snake or camel case names: e.g. editing.new_value or liveWire.someAttribute

I assume it's not possible?