### PR TITLE
Add assertDontSeeLivewire assertion to testing

### DIFF
--- a/testing.blade.php
+++ b/testing.blade.php
@@ -86,7 +86,7 @@ class CreatePostTest extends TestCase
 
 ## Testing Component Presence {#testing-component-presence}
 
-Livewire registers a handy PHPUnit method to test for a component's presence on a page.
+Livewire registers handy PHPUnit methods for testing a components presence on a page.
 
 @component('components.code', ['lang' => 'php'])
 class CreatePostTest extends TestCase
@@ -95,6 +95,12 @@ class CreatePostTest extends TestCase
     function post_creation_page_contains_livewire_component()
     {
         $this->get('/posts/create')->assertSeeLivewire('create-post');
+    }
+
+    /** @test */
+    function post_creation_page_doesnt_contains_livewire_component()
+    {
+        $this->get('/posts/create')->assertDontSeeLivewire('edit-post');
     }
 }
 @endcomponent


### PR DESCRIPTION
Hey there.&nbsp; 👏

I noticed when testing with Livewire that a useful assertion, namely the `assertDontSeeLivewire` assertion isn't written about anywhere in the documentation, I only found out about it when looking through the source to see how `assertSeeLivewire` was made. 🙂

This PR adds a test including said assertion just below the latter one to show that such a helper method does indeed exist.
Neither of the methods exists in the reference on testing helpers either so I'm wondering should I add both to the reference in another PR @calebporzio?

### Screenshot from before

![Screen Shot 2021-01-08 at 11 30 51 PM](https://user-images.githubusercontent.com/2221746/104071541-aa489980-5209-11eb-916d-18031e0f0ae8.png)

### Screenshot from after

![Screen Shot 2021-01-08 at 11 30 37 PM](https://user-images.githubusercontent.com/2221746/104071533-a583e580-5209-11eb-8449-2fc17264b1cc.png)