### PR TITLE
Add missing PHPUnit helpers to testing methods on reference page

### DIFF
--- a/reference.blade.php
+++ b/reference.blade.php
@@ -255,6 +255,15 @@ Name |
 `->assertViewIs('livewire.some-view-name')` |
 @endcomponent
 
+There are also PHPUnit helpers available to check the presence of a component.
+
+@component('components.table')
+Name |
+--- |
+`->assertSeeLivewire($component)` |
+`->assertDontSeeLivewire($component)` |
+@endcomponent
+
 ### Artisan Commands
 
 These are the `artisan` commands Livewire makes available to make frequent tasks like creating a component easier.


### PR DESCRIPTION
Hello.&nbsp; 👏

This PR adds the PHPUnit helpers methods to the reference page, they seem to be a bit hidden so thought it'd be a good idea to add them to the reference page as I mentioned in #311. 🙂

### Screenshot of before

![Screen Shot 2021-01-09 at 1 25 44 AM](https://user-images.githubusercontent.com/2221746/104077446-04e9f180-521a-11eb-981b-00d1ee261843.png)

### Screenshot of after

![Screen Shot 2021-01-09 at 1 25 31 AM](https://user-images.githubusercontent.com/2221746/104077439-01566a80-521a-11eb-9198-5e8eab769b6f.png)