### PR TITLE
Clarify laravel-echo.blade.php

### DIFF
--- a/laravel-echo.blade.php
+++ b/laravel-echo.blade.php
@@ -88,3 +88,8 @@ class OrderTracker extends Component
 }
 @endslot
 @endcomponent
+
+@component('components.warning')
+    Please keep in mind that the method above does not work with events that have a custom name which is defined in your event's `public function broadcastAs()`
+    because Livewire internally appends `App\Events\` to the event name. 
+@endcomponent


### PR DESCRIPTION
Livewire internally appends ``App\Events\`` to the event's name. This causes conflicts with custom event names via an event's ``public function broadcastAs()``. 
The PR aims to clarify this.