### PR TITLE
Add a note for keys in paginated results

### DIFF
--- a/troubleshooting.blade.php
+++ b/troubleshooting.blade.php
@@ -48,8 +48,8 @@ If you are using pagination, you're better off using a `key` that doesn't come f
         <!-- key() using Laravel 7's tag syntax -->
         <livewire:view-item :item="$item" :key="$loop->index">
     @endforeach
-    {{ $paginatedItems->links() }}
 </ul>
+{{ $paginatedItems->links() }}
 @endverbatim
 @endcomponent
 

--- a/troubleshooting.blade.php
+++ b/troubleshooting.blade.php
@@ -37,6 +37,22 @@ For the most part, this system is reliable, but there are certain cases where Li
 @endverbatim
 @endcomponent
 
+If you are using pagination, you're better off using a `key` that doesn't come from the `$loop` variable because you might end up with two different livewire component with the same `key`
+
+@component('components.code')
+@verbatim
+<ul>
+    @foreach ($paginatedItems as $item)
+        @livewire('view-item', ['item' => $item], key($item->id))
+
+        <!-- key() using Laravel 7's tag syntax -->
+        <livewire:view-item :item="$item" :key="$loop->index">
+    @endforeach
+    {{ $paginatedItems->links() }}
+</ul>
+@endverbatim
+@endcomponent
+
 * Wrap Blade conditionals (`@@if`, `@@error`, `@@auth`) in an element
 @component('components.code')
 @verbatim


### PR DESCRIPTION
The problem with using `$loop->index` as a key in a paginated result is the fact it might duplicate. 
For example: Lets say we have somewhere between 11 to 20 items, paginated with 10 items per page.
On page 2, the first  view-item component (for item 11)  will have `:key=0` which is the same as the first item from page 1. This can cause the wrong data to appear in the component.