### PR TITLE
Add info about getRules() and getQueryString() methods

### DIFF
--- a/input-validation.blade.php
+++ b/input-validation.blade.php
@@ -54,6 +54,26 @@ You can also add custom key/message pairs to the error bag.
 @endverbatim
 @endcomponent
 
+If you need to define rules dynamically, you can substitute the `$rules` property for the `getRules()` method on the component:
+
+@component('components.code', ['lang' => 'php'])
+@verbatim
+class ContactForm extends Component
+{
+    public $name;
+    public $email;
+
+    protected function getRules()
+    {
+        return [
+            'name' => 'required|min:6',
+            'email' => ['required', 'email', 'not_in:' . auth()->user()->email],
+        ];
+    }
+}
+@endverbatim
+@endcomponent
+
 ## Real-time Validation {#real-time-validation}
 
 Sometimes it's useful to validate a form field as a user types into it. Livewire makes "real-time" validation simple with the `$this->validateOnly()` method.

--- a/query-string.blade.php
+++ b/query-string.blade.php
@@ -42,6 +42,31 @@ class SearchPosts extends Component
 @endslot
 @endcomponent
 
+If you need to define the query string dynamically, you can substitute the `$queryString` property for the `getQueryString()` method on the component:
+
+@component('components.code', ['lang' => 'php'])
+@verbatim
+class SearchPosts extends Component
+{
+    public $search;
+    public $author;
+
+    public function getQueryString(): array
+    {
+        return [
+            'search' => ['except' => ''],
+            'author' => ['except' => auth()->id()],
+        ];
+    }
+
+    public function mount()
+    {
+        $this->author = auth()->id();
+    }
+}
+@endverbatim
+@endcomponent
+
 ### Keeping A Clean Query String {#clean-query-string}
 
 In the case above, when the search property is empty, the query string will look like this:


### PR DESCRIPTION
Added info about `getRules()` and `getQueryString()` getter methods just like for the [event listeners](https://laravel-livewire.com/docs/2.x/events#event-listeners).