### PR TITLE
Added information for no root element

### DIFF
--- a/troubleshooting.blade.php
+++ b/troubleshooting.blade.php
@@ -10,6 +10,7 @@ For the most part, this system is reliable, but there are certain cases where Li
 * An element or group of elements dissapears suddenly
 * A previously interactive element stops responding to user input
 * A loading indicator mis-fires
+* Not providing a root element
 
 ### Cures:
 * Add `wire:key` to elements inside loops:

--- a/troubleshooting.blade.php
+++ b/troubleshooting.blade.php
@@ -10,9 +10,10 @@ For the most part, this system is reliable, but there are certain cases where Li
 * An element or group of elements dissapears suddenly
 * A previously interactive element stops responding to user input
 * A loading indicator mis-fires
-* Not providing a root element
+* A user action no longer functions
 
 ### Cures:
+* Ensure your component has a single-level root element
 * Add `wire:key` to elements inside loops:
 @component('components.code')
 @verbatim


### PR DESCRIPTION
After speaking to @GertjanRoke, I didn't realise that elements needed a root dom element. This led me to experience an issuer where only one element on my page would allow me to run my function, whereas the others wouldn't do anything at all.

Also to this, is there a possibility of being able to add a warning when not specifying a root element, as this could be something someone misses -  I myself missed this completely somehow through the docs.

Hopefully this change within the documentation will cover what is needed, as it could help for those going to the troubleshooting page.