### PR TITLE
Add how to use lifecycle hooks with multiword property names

### DIFF
--- a/lifecycle-hooks.blade.php
+++ b/lifecycle-hooks.blade.php
@@ -16,8 +16,8 @@ updating | Runs before any update to the Livewire component's data (Using `wire:
 updated | Runs after any update to the Livewire component's data (Using `wire:model`, not directly inside PHP)
 updatingFoo | Runs before a property called `$foo` is updated
 updatedFoo | Runs after a property called `$foo` is updated
-updatingFooBar | Runs before updating a nested property `bar` on the `$foo` property
-updatedFooBar | Runs after updating a nested property `bar` on the `$foo` property
+updatingFooBar | Runs before updating a nested property `bar` on the `$foo` property or a multiword property such as `$fooBar` or `$foo_bar`
+updatedFooBar | Runs after updating a nested property `bar` on the `$foo` property or a multiword property such as `$fooBar` or `$foo_bar`
 @endcomponent
 
 @component('components.code', ['lang' => 'php'])


### PR DESCRIPTION
I ran into an issue where my updated lifecycle hook was not working properly, and then I got led even further astray because the docs state that multiword lifecycle hook names are for targeting nested properties, with no mention anywhere (as far as I'm aware) of how to target camel case or pascal case properties.