### PR TITLE
Fix parameter order for updating & updated methods

### DIFF
--- a/lifecycle-hooks.blade.php
+++ b/lifecycle-hooks.blade.php
@@ -50,12 +50,12 @@ class HelloWorld extends Component
         //
     }
 
-    public function updating($value, $name)
+    public function updating($name, $value)
     {
         //
     }
 
-    public function updated($value, $name)
+    public function updated($name, $value)
     {
         //
     }


### PR DESCRIPTION
Hi Caleb,

I noticed that the parameters are actually ordered $name, $value.