### PR TITLE
Fixes inverted method parameters of methods "updated" and "updating"

### DIFF
--- a/lifecycle-hooks.blade.php
+++ b/lifecycle-hooks.blade.php
@@ -50,12 +50,12 @@ class HelloWorld extends Component
         //
     }
 
-    public function updating($value, $name)
+    public function updating($name, $value)
     {
         //
     }
 
-    public function updated($value, $name)
+    public function updated($name, $value)
     {
         //
     }


### PR DESCRIPTION
Hi all,

when developing I recognized that the parameters in the documentation are in an inverted order.

So this part of the lifecycle hook examples:
```
...
    public function updating($value, $name)
    {
        //
    }

    public function updated($value, $name)
    {
        //
    }
...
```

should be:
```
...
    public function updating($name, $value)
    {
        //
    }

    public function updated($name, $value)
    {
        //
    }
...
```

This is a PR for fixing this.

Best regards,
Jan