### PR TITLE
Fix default pagination example

### DIFF
--- a/pagination.blade.php
+++ b/pagination.blade.php
@@ -149,30 +149,36 @@ See below for an example of how the default livewire paginator works.
 
 @component('components.code', ['lang' => 'php'])
 @verbatim
-@if ($paginator->hasPages())
-    <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
-        {{-- Previous Page Link --}}
-        @if ($paginator->onFirstPage())
-            <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">
-                {!! __('pagination.previous') !!}
+<div>
+    @if ($paginator->hasPages())
+        <nav role="navigation" aria-label="Pagination Navigation" class="flex justify-between">
+            <span>
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">
+                        {!! __('pagination.previous') !!}
+                    </span>
+                @else
+                    <button wire:click="previousPage" wire:loading.attr="disabled" rel="prev" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        {!! __('pagination.previous') !!}
+                    </button>
+                @endif
             </span>
-        @else
-            <a href="{{ $paginator->previousPageUrl() }}" rel="prev" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
-                {!! __('pagination.previous') !!}
-            </a>
-        @endif
 
-        {{-- Next Page Link --}}
-        @if ($paginator->hasMorePages())
-            <a href="{{ $paginator->nextPageUrl() }}" rel="next" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
-                {!! __('pagination.next') !!}
-            </a>
-        @else
-            <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">
-                {!! __('pagination.next') !!}
+            <span>
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <button wire:click="nextPage" wire:loading.attr="disabled" rel="next" class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 rounded-md hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150">
+                        {!! __('pagination.next') !!}
+                    </button>
+                @else
+                    <span class="relative inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 rounded-md">
+                        {!! __('pagination.next') !!}
+                    </span>
+                @endif
             </span>
-        @endif
-    </nav>
-@endif
+        </nav>
+    @endif
+</div>
 @endverbatim
 @endcomponent


### PR DESCRIPTION
The example of the "default livewire paginator" doesn't actually use livewire or the wire:click="nextPage" features.

Replaced the example code with the current version of simple-tailwind.blade.php as a true example of how the default livewire paginator works!