### PR TITLE
Config flag is no longer necessary to publish config

### DIFF
--- a/installation.blade.php
+++ b/installation.blade.php
@@ -51,7 +51,7 @@ You can publish Livewire's config file with the following artisan command:
 
 @component('components.code', ['lang' => 'bash'])
 @verbatim
-php artisan livewire:publish --config
+php artisan livewire:publish
 @endverbatim
 @endcomponent
 


### PR DESCRIPTION
I needed to publish the config file and got this error

```bash
→ php artisan livewire:publish --config
The "--config" option does not exist.
```
The `--config` is no longer necessary. This PR fixes the docs