### PR TITLE
Add a missing word to Javascript Hooks docs.

### DIFF
--- a/reference.blade.php
+++ b/reference.blade.php
@@ -89,7 +89,7 @@ Method | Description
 
 ### JavaScript Hooks {#js-hooks}
 
-These are "hooks" you can listen for in JavaScript. These allow you to hook into very specific parts of a Livewire component's JavaScript lifecycle for third-party packages or deep customizations. The abilities unlocked here are immense. A significant of Livewire's core uses these hooks to provide functionality.
+These are "hooks" you can listen for in JavaScript. These allow you to hook into very specific parts of a Livewire component's JavaScript lifecycle for third-party packages or deep customizations. The abilities unlocked here are immense. A significant portion of Livewire's core uses these hooks to provide functionality.
 
 @component('components.code', ['lang' => 'javascript'])
 Livewire.hook('component.initialized', component => {


### PR DESCRIPTION
Changes:

"A a significant of Livewire's core uses..."

To:

"A a significant portion of Livewire's core uses..."