### PR TITLE
Add example for $refresh magic action in backend

### DIFF
--- a/actions.blade.php
+++ b/actions.blade.php
@@ -197,3 +197,19 @@ Let's take `$set()` for example. It can be used to manually set a component prop
 @endcomponent
 
 Notice that we are no longer calling the `setMessageToHello` function, we are directly specifying, what we want data set to.
+
+It can also be used in the backend when listening for an event. For example, if you have one component that emits an event like this:
+
+@component('components.code', ['lang' => 'php'])
+@verbatim
+$this->emit('some-event');
+@endverbatim
+@endcomponent
+
+Then in another component you can use a magic action for example `$refresh()` instead of having to point the listener to a method:
+
+@component('components.code', ['lang' => 'php'])
+@verbatim
+protected $listeners = ['some-event' => '$refresh'];
+@endverbatim
+@endcomponent


### PR DESCRIPTION
Added an example of using the `$refresh` magic method on the backend as a shorthand instead of pointing the event listener to a method.