### PR TITLE
@error directive does not work because of curly brackets

### DIFF
--- a/properties.blade.php
+++ b/properties.blade.php
@@ -310,7 +310,7 @@ class EditUsersPosts extends Component
         <input type="text" wire:model="user.posts.{{ $i }}.title" />
         
         <span class="error">
-            @error('user.posts.{{ $i }}.title') {{ $message }} @enderror
+            @error('user.posts.'.$i.'.title') {{ $message }} @enderror
         </span>
     @endforeach
 


### PR DESCRIPTION
curly brackets doesn't work here, because you are already "inside php" when using the @error directive