### PR TITLE
Update docs to clarify that the mount function is only called once

### DIFF
--- a/lifecycle-hooks.blade.php
+++ b/lifecycle-hooks.blade.php
@@ -9,7 +9,7 @@ Hooks | Description
 --- | ---
 boot | Runs on every request, immediately after the component is instantiated, but before any other lifecycle methods are called
 booted | Runs on every request, after the component is mounted or hydrated, but before any update methods are called
-mount | Runs once, immediately after the component is instantiated, but before `render()` is called
+mount | Runs once, immediately after the component is instantiated, but before `render()` is called. This is only called once on initial page load, and never called again, even on component refreshes.
 hydrate | Runs on every subsequent request, after the component is hydrated, but before an action is performed, or `render()` is called
 hydrateFoo | Runs after a property called `$foo` is hydrated
 dehydrate | Runs on every subsequent request, before the component is dehydrated, but after `render()` is called

--- a/lifecycle-hooks.blade.php
+++ b/lifecycle-hooks.blade.php
@@ -9,7 +9,7 @@ Hooks | Description
 --- | ---
 boot | Runs on every request, immediately after the component is instantiated, but before any other lifecycle methods are called
 booted | Runs on every request, after the component is mounted or hydrated, but before any update methods are called
-mount | Runs once, immediately after the component is instantiated, but before `render()` is called. This is only called once on initial page load, and never called again, even on component refreshes.
+mount | Runs once, immediately after the component is instantiated, but before `render()` is called. This is only called once on initial page load and never called again, even on component refreshes
 hydrate | Runs on every subsequent request, after the component is hydrated, but before an action is performed, or `render()` is called
 hydrateFoo | Runs after a property called `$foo` is hydrated
 dehydrate | Runs on every subsequent request, before the component is dehydrated, but after `render()` is called

--- a/rendering-components.blade.php
+++ b/rendering-components.blade.php
@@ -104,7 +104,7 @@ class ShowPost extends Component
 @component('components.tip')
 In Livewire components, you use <code>mount()</code> instead of a class constructor <code>__construct()</code> like you may be used to.
 
-NB: <code>mount()</code> is only ever called when the component is first mounted, and will not be called again, even when the component is updated.
+NB: <code>mount()</code> is only ever called when the component is first mounted and will not be called again even when the component is refreshed or rerendered.
 @endcomponent
 
 

--- a/rendering-components.blade.php
+++ b/rendering-components.blade.php
@@ -103,6 +103,8 @@ class ShowPost extends Component
 
 @component('components.tip')
 In Livewire components, you use <code>mount()</code> instead of a class constructor <code>__construct()</code> like you may be used to.
+
+NB: <code>mount()</code> is only ever called when the component is first mounted, and will not be called again, even when the component is updated.
 @endcomponent
 
 


### PR DESCRIPTION
Was having an issue setting data in the `mount()` function, thinking it'd be called with each refresh, but it never is. So have clarified this on the docs.