### PR TITLE
Add TOC and headings IDs

### DIFF
--- a/actions.blade.php
+++ b/actions.blade.php
@@ -1,12 +1,10 @@
-* [Introduction](#introduction) { .text-blue-800 }
-* [Passing Action Parameters](#action-parameters) { .text-blue-800 }
-* [Event Modifiers](#event-modifiers) { .text-blue-800 }
-  * [Keydown Modifiers](#keydown-modifiers) { .font-normal.text-sm.text-blue-800 }
-* [Magic Actions](#magic-actions) { .text-blue-800 }
-
-<div>&nbsp;</div>
-
 @include('includes.screencast-cta')
+
+* [Introduction](#introduction)
+* [Passing Action Parameters](#action-parameters)
+* [Event Modifiers](#event-modifiers)
+  * [Keydown Modifiers](#keydown-modifiers)
+* [Magic Actions](#magic-actions)
 
 ## Introduction {#introduction}
 

--- a/actions.blade.php
+++ b/actions.blade.php
@@ -1,5 +1,3 @@
-@include('includes.screencast-cta')
-
 * [Introduction](#introduction)
 * [Passing Action Parameters](#action-parameters)
 * [Event Modifiers](#event-modifiers)

--- a/alpine-js.blade.php
+++ b/alpine-js.blade.php
@@ -1,3 +1,14 @@
+* [Installation](#installation)
+* [Using Alpine Inside Of Livewire](#alpine-in-livewire)
+* [Extracting Reusable Blade Components](#extracting-blade-components)
+* [Interacting With Livewire From Alpine: `$wire`](#interacting-with-livewire-from-alpine)
+* [Sharing State Between Livewire And Alpine: @verbatim`@entangle`@endverbatim](#sharing-state)
+* [Using the `@verbatim@js@endverbatim` directive](#js-directive)
+* [Accessing Livewire Directives From Blade Components](#livewire-directives-from-blade-components)
+* [Creating A DatePicker Component](#creating-a-datepicker)
+* [Forwarding `wire:model` `input` Events](#forwarding-wire-model-input-events)
+* [Ignoring DOM-changes (using `wire:ignore`)](#ignoring-dom-changes)
+
 There are lots of instances where a page interaction doesn't warrant a full server-roundtrip, like toggling a modal.
 
 For these cases, AlpineJS is the perfect companion to Livewire.
@@ -91,7 +102,7 @@ Here is an example (Using Laravel 7 Blade component tag syntax).
 
 Now, the Livewire and Alpine syntaxes are completely separate, AND you have a reusable Blade component to use from other components.
 
-## Interacting With Livewire From Alpine: `$wire`
+## Interacting With Livewire From Alpine: `$wire` {#interacting-with-livewire-from-alpine}
 
 From any Alpine component inside a Livewire component, you can access a magic `$wire` object to access and manipulate the Livewire component.
 
@@ -193,7 +204,7 @@ $wire.removeUpload(
 $wire.__instance
 @endcomponent
 
-## Sharing State Between Livewire And Alpine: @verbatim`@entangle`@endverbatim
+## Sharing State Between Livewire And Alpine: @verbatim`@entangle`@endverbatim {#sharing-state}
 Livewire has an incredibly powerful feature called "entangle" that allows you to "entangle" a Livewire and Alpine property together. With entanglement, when one value changes, the other will also be changed.
 
 To demonstrate, consider the dropdown example from before, but now with its `showDropdown` property entangled between Livewire and Alpine. By using entanglement, we are now able to control the state of the dropdown from both Alpine AND Livewire.
@@ -248,7 +259,7 @@ Now, when a user toggles the dropdown open and closed, there will be no AJAX req
 
 If you are having trouble following this difference. Open your browser's devtools and observe the difference in XHR requests with and without `.defer` added.
 
-## Using the `@verbatim@js@endverbatim` directive
+## Using the `@verbatim@js@endverbatim` directive {#js-directive}
 
 If ever you need to output PHP data for use in Alpine, you can now use the `@verbatim@js@endverbatim` directive.
 
@@ -260,7 +271,7 @@ If ever you need to output PHP data for use in Alpine, you can now use the `@ver
 @endverbatim
 @endcomponent
 
-## Accessing Livewire Directives From Blade Components
+## Accessing Livewire Directives From Blade Components {#livewire-directives-from-blade-components}
 Extracting re-usable Blade components within your Livewire application is an essential pattern.
 
 One difficulty you might encounter while implementing Blade components within a Livewire context is accessing the value of attributes like `wire:model` from inside the component.
@@ -408,7 +419,7 @@ Now let's see how we might write a re-usable Blade component for this library.
 
 > Note: The @verbatim {{ $attributes }} @endverbatim expression is a mechanism in Laravel 7 and above to forward extra HTML attributes declared on the component tag.
 
-## Forwarding `wire:model` `input` Events
+## Forwarding `wire:model` `input` Events {#forwarding-wire-model-input-events}
 
 Under the hood, `wire:model` adds an event listener to update a property every time the `input` event is dispatched on or under the element. Another way to communicate between Livewire and Alpine is by using Alpine to dispatch an `input` event with some data within or on an element with `wire:model` on it.
 
@@ -492,7 +503,7 @@ This sample assumes you have it loaded on the page.
 @endverbatim
 @endcomponent
 
-## Ignoring DOM-changes (using `wire:ignore`)
+## Ignoring DOM-changes (using `wire:ignore`) {#ignoring-dom-changes}
 
 Fortunately a library like Pikaday adds its extra DOM at the end of the page. Many other libraries manipulate the DOM as soon as they are initialized and continue to mutate the DOM as you interact with them.
 

--- a/artisan-commands.blade.php
+++ b/artisan-commands.blade.php
@@ -1,4 +1,10 @@
-## The `make` command
+* [The `make` command](#make-command)
+    * [Modifying Stubs](#modifying-stubs)
+* [The `move` Command](#move-command)
+* [The `copy` Command](#copy-command)
+* [The `delete` Command](#delete-command)
+
+## The `make` command {#make-command}
 
 @component('components.code', ['lang' => 'shell'])
 php artisan make:livewire foo

--- a/authorization.blade.php
+++ b/authorization.blade.php
@@ -1,3 +1,6 @@
+* [Introduction](#introduction)
+
+## Introduction {#introduction}
 
 To authorize actions in Livewire, you can use the `AuthorizesRequests` trait in any component, then call `$this->authorize()` like you normally would inside a controller. For example:
 

--- a/contribution-guide.blade.php
+++ b/contribution-guide.blade.php
@@ -1,21 +1,20 @@
+* [Setup Livewire locally](#setup-livewire-locally)
+    * [Fork Livewire](#fork-livewire)
+    * [Git clone your fork locally](#clone-fork)
+    * [Install dependencies](#install-dependencies)
+    * [Configure dusk](#configure-dusk)
+    * [Run tests](#setup-run-tests)
+* [Bug fix/ feature development](#bug-fix-feature-development)
+    * [Create a branch](#create-a-branch)
+    * [Add failing tests](#add-failing-tests)
+    * [Add working code](#add-working-code)
+    * [Run tests](#development-run-tests)
+    * [Submit PR](#submit-pr)
+    * [Thanks for contributing! 🙌](#thanks)
+
 At Livewire we appreciate and welcome all contributions!
 
 If that's something you would be interested in doing, we recommend going through this contribution guide first before starting.
-
-* [Setup Livewire locally](#setup-livewire-locally) { .text-blue-800 }
-    * [Fork Livewire](#fork-livewire) { .font-normal.text-sm.text-blue-800 }
-    * [Git clone your fork locally](#clone-fork) { .font-normal.text-sm.text-blue-800 }
-    * [Install dependencies](#install-dependencies) { .font-normal.text-sm.text-blue-800 }
-    * [Configure dusk](#configure-dusk) { .font-normal.text-sm.text-blue-800 }
-    * [Run tests](#setup-run-tests) { .font-normal.text-sm.text-blue-800 }
-* [Bug fix/ feature development](#bug-fix-feature-development) { .text-blue-800 }
-    * [Create a branch](#create-a-branch) { .font-normal.text-sm.text-blue-800 }
-    * [Add failing tests](#add-failing-tests) { .font-normal.text-sm.text-blue-800 }
-    * [Add working code](#add-working-code) { .font-normal.text-sm.text-blue-800 }
-    * [Run tests](#development-run-tests) { .font-normal.text-sm.text-blue-800 }
-    * [Submit PR](#submit-pr) { .font-normal.text-sm.text-blue-800 }
-    * [Thanks for contributing! 🙌](#thanks) { .font-normal.text-sm.text-blue-800 }
-
 
 ## Setup Livewire locally {#setup-livewire-locally}
 

--- a/defer-loading.blade.php
+++ b/defer-loading.blade.php
@@ -1,3 +1,6 @@
+* [Introduction](#introduction)
+
+## Introduction {#introduction}
 
 Livewire offers a `wire:init` directive to run an action as soon as the component is rendered. This can be helpful in cases where you don't want to hold up the entire page load, but want to load some data immediately after the page load.
 

--- a/deployment.blade.php
+++ b/deployment.blade.php
@@ -1,7 +1,7 @@
-* [Livewire Changes](#livewire-changes) { .text-blue-800 }
-* [Page Expired Dialog and Hook](#page-expired-dialog-and-hook) { .text-blue-800 }
-    * [Page Expired Dialog](#page-expired-dialog) { .text-blue-800 }
-    * [Page Expired Hook](#page-expired-hook) { .text-blue-800 }
+* [Livewire Changes](#livewire-changes)
+* [Page Expired Dialog and Hook](#page-expired-dialog-and-hook)
+    * [Page Expired Dialog](#page-expired-dialog)
+    * [Page Expired Hook](#page-expired-hook)
 
 ## Livewire Changes {#livewire-changes}
 

--- a/dirty-states.blade.php
+++ b/dirty-states.blade.php
@@ -1,3 +1,6 @@
+* [Toggling classes on "dirty" elements](#toggling-classes)
+* [Toggling elements](#toggling-elements)
+* [Toggling classes on other elements](#toggling-classes)
 
 There are cases where it may be useful to provide feedback that content has changed and is not yet in-sync with the back-end Livewire component.
 

--- a/events.blade.php
+++ b/events.blade.php
@@ -1,19 +1,17 @@
-* [Firing Events](#firing-events) { .text-blue-800 }
-  * [From The Template](#from-template) { .font-normal.text-sm.text-blue-800 }
-  * [From The Component](#from-component) { .font-normal.text-sm.text-blue-800 }
-  * [From Global JavaScript](#from-js) { .font-normal.text-sm.text-blue-800 }
-* [Event Listeners](#event-listeners) { .text-blue-800 }
-* [Passing Parameters](#passing-parameters) { .text-blue-800 }
-* [Scoping Events](#scoping-events) { .text-blue-800 }
-  * [Scoping To Parent Listeners](#scope-to-parents) { .font-normal.text-sm.text-blue-800 }
-  * [Scoping To Components By Name](#scope-by-name) { .font-normal.text-sm.text-blue-800 }
-  * [Scoping To Self](#scope-to-self) { .font-normal.text-sm.text-blue-800 }
-* [Listening For Events In JavaScript](#in-js) { .text-blue-800 }
-* [Dispatching Browser Events](#browser) { .text-blue-800 }
-
-<div>&nbsp;</div>
-
 @include('includes.screencast-cta')
+
+* [Firing Events](#firing-events)
+  * [From The Template](#from-template)
+  * [From The Component](#from-component)
+  * [From Global JavaScript](#from-js)
+* [Event Listeners](#event-listeners)
+* [Passing Parameters](#passing-parameters)
+* [Scoping Events](#scoping-events)
+  * [Scoping To Parent Listeners](#scope-to-parents)
+  * [Scoping To Components By Name](#scope-by-name)
+  * [Scoping To Self](#scope-to-self)
+* [Listening For Events In JavaScript](#in-js)
+* [Dispatching Browser Events](#browser)
 
 Livewire components can communicate with each other through a global event system. As long as two Livewire components are living on the same page, they can communicate using events and listeners.
 

--- a/events.blade.php
+++ b/events.blade.php
@@ -1,5 +1,3 @@
-@include('includes.screencast-cta')
-
 * [Firing Events](#firing-events)
   * [From The Template](#from-template)
   * [From The Component](#from-component)

--- a/file-downloads.blade.php
+++ b/file-downloads.blade.php
@@ -1,3 +1,8 @@
+* [Introduction](#introduction)
+* [Testing File Downloads](#testing-file-downloads)
+
+## Introduction {#introduction}
+
 Livewire supports triggering file downloads for users with a simple, intuitive API.
 
 To trigger a file download, you can return a Laravel file download from any component action.
@@ -39,7 +44,7 @@ return response()->streamDownload(function () {
 @endverbatim
 @endcomponent
 
-## Testing File Downloads
+## Testing File Downloads {#testing-file-downloads}
 Testing file downloads is simple with livewire.
 
 Here is an example of testing the component above and making sure the export was downloaded.

--- a/file-uploads.blade.php
+++ b/file-uploads.blade.php
@@ -1,5 +1,3 @@
-@include('includes.screencast-cta')
-
 * [Basic Upload](#basic-upload)
   * [Storing Uploaded Files](#storing-files)
 * [Handling Multiple Files](#multiple-files)

--- a/file-uploads.blade.php
+++ b/file-uploads.blade.php
@@ -1,23 +1,21 @@
-* [Basic Upload](#basic-upload) { .text-blue-800 }
-  * [Storing Uploaded Files](#storing-files) { .font-normal.text-sm.text-blue-800 }
-* [Handling Multiple Files](#multiple-files) { .text-blue-800 }
-* [File Validation](#file-validation) { .text-blue-800 }
-  * [Real-time Validation](#real-time-validation) { .font-normal.text-sm.text-blue-800 }
-* [Temporary Preview Urls](#preview-urls) { .text-blue-800 }
-* [Testing File Uploads](#testing-uploads) { .text-blue-800 }
-* [Uploading Directly To Amazon S3](#upload-to-s3) { .text-blue-800 }
-  * [Configuring Automatic File Cleanup](#auto-cleanup) { .font-normal.text-sm.text-blue-800 }
-* [Loading Indicators](#loading-indicators) { .text-blue-800 }
-* [Progress Indicators (And All JavaScript Events)](#js-hooks) { .text-blue-800 }
-* [JavaScript Upload API](#js-api) { .text-blue-800 }
-* [Configuration](#configuration) { .text-blue-800 }
-  * [Global Validation](#global-validation) { .font-normal.text-sm.text-blue-800 }
-  * [Global Middleware](#global-middleware) { .font-normal.text-sm.text-blue-800 }
-  * [Temporary Upload Directory](#temporary-upload-directory) { .font-normal.text-sm.text-blue-800 }
-
-<div>&nbsp;</div>
-
 @include('includes.screencast-cta')
+
+* [Basic Upload](#basic-upload)
+  * [Storing Uploaded Files](#storing-files)
+* [Handling Multiple Files](#multiple-files)
+* [File Validation](#file-validation)
+  * [Real-time Validation](#real-time-validation)
+* [Temporary Preview Urls](#preview-urls)
+* [Testing File Uploads](#testing-uploads)
+* [Uploading Directly To Amazon S3](#upload-to-s3)
+  * [Configuring Automatic File Cleanup](#auto-cleanup)
+* [Loading Indicators](#loading-indicators)
+* [Progress Indicators (And All JavaScript Events)](#js-hooks)
+* [JavaScript Upload API](#js-api)
+* [Configuration](#configuration)
+  * [Global Validation](#global-validation)
+  * [Global Middleware](#global-middleware)
+  * [Temporary Upload Directory](#temporary-upload-directory)
 
 ## Basic File Upload {#basic-upload}
 

--- a/flash-messages.blade.php
+++ b/flash-messages.blade.php
@@ -1,3 +1,6 @@
+* [Introduction](#introduction)
+
+## Introduction {#introduction}
 
 In cases where it's useful to "flash" a success or failure message to the user, Livewire supports Laravel's system for flashing data to the session.
 

--- a/inline-scripts.blade.php
+++ b/inline-scripts.blade.php
@@ -1,3 +1,9 @@
+* [Introduction](#introduction)
+* [Using the `@verbatim@js@endverbatim` directive](#using-js-directive)
+* [Accessing the JavaScript component instance](#accessing-javascript-component-instance)
+
+## Introduction {#introduction}
+
 Livewire recommends that you use AlpineJS for most of your JavaScript needs, but it does support using `<script>` tags directly inside your component's view.
 
 @component('components.code', ['lang' => 'blade'])
@@ -32,7 +38,7 @@ You can also push scripts directly onto Blade stacks from your Livewire componen
 @endverbatim
 @endcomponent
 
-### Using the `@verbatim@js@endverbatim` directive
+## Using the `@verbatim@js@endverbatim` directive {#using-js-directive}
 
 If ever you need to output PHP data for use in Javascript, you can now use the `@verbatim@js@endverbatim` directive.
 
@@ -46,7 +52,7 @@ If ever you need to output PHP data for use in Javascript, you can now use the `
 @endverbatim
 @endcomponent
 
-### Accessing the JavaScript component instance
+## Accessing the JavaScript component instance {#accessing-javascript-component-instance}
 
 Because Livewire has both a PHP AND a JavaScript portion, each component also has a JavaScript object. You can access this object using the special `@@this` blade directive in your component's view.
 

--- a/input-validation.blade.php
+++ b/input-validation.blade.php
@@ -1,3 +1,13 @@
+* [Introduction](#introduction)
+* [Real-time Validation](#real-time-validation)
+* [Validating with rules outside of the `$rules` property](#validating-with-other-rules)
+* [Customize Error Message & Attributes](#customize-error-message-and-attributes)
+* [Direct Error Message Manipulation](#error-bag-manipulation)
+* [Access Validator instance](#access-validator-instance)
+* [Testing Validation](#testing-validation)
+* [Custom validators](#custom-validators)
+
+## Introduction {#introduction}
 
 Validation in Livewire should feel similar to standard form validation in Laravel. In short, Livewire provides a `$rules` property for setting validation rules on a per-component basis, and a `$this->validate()` method for validating a component's properties using those rules.
 
@@ -131,7 +141,7 @@ Let's break down exactly what is happening in this example:
 
 If you are wondering, "why do I need `validateOnly`? Can't I just use `validate`?". The reason is because otherwise, every single update to any field would validate ALL of the fields. This can be a jarring user experience. Imagine if you typed one character into the first field of a form, and all of a sudden every single field had a validation message. `validateOnly` prevents that, and only validates the current field being updated.
 
-## Validating with rules outside of the `$rules` property
+## Validating with rules outside of the `$rules` property {#validating-with-other-rules}
 If for whatever reason you want to validate using rules other than the ones defined in the `$rules` property, you can always do this by passing the rules directly into the `validate()` and `validateOnly()` methods.
 
 @component('components.code-component')
@@ -164,7 +174,7 @@ class ContactForm extends Component
 @endslot
 @endcomponent
 
-## Customize Error Message & Attributes
+## Customize Error Message & Attributes {#customize-error-message-and-attributes}
 
 If you wish to customize the validation messages used by a Livewire component, you can do so with the `$messages` property.
 
@@ -262,7 +272,7 @@ $errors->add('some-key', 'Some message');
 @endverbatim
 @endcomponent
 
-## Access Validator instance
+## Access Validator instance {#access-validator-instance}
 
 Sometimes you may want to access the Validator instance that Livewire uses in the `validate()` and `validateOnly()` methods. This is possible using the `withValidator` method. The closure you provide receives the fully constructed validator as an argument, allowing you to call any of its methods before the validation rules are actually evaluated.
 

--- a/installation.blade.php
+++ b/installation.blade.php
@@ -1,5 +1,3 @@
-@include('includes.screencast-cta')
-
 * [Requirements](#requirements)
 * [Install The Package](#install-package)
 * [Include The Assets](#include-js)

--- a/installation.blade.php
+++ b/installation.blade.php
@@ -1,5 +1,12 @@
 @include('includes.screencast-cta')
 
+* [Requirements](#requirements)
+* [Install The Package](#install-package)
+* [Include The Assets](#include-js)
+* [Publishing The Config File](#publishing-config)
+* [Publishing Frontend Assets](#publish-assets)
+* [Configuring The Asset Base URL](#configuring-the-asset-base-url)
+
 ## Requirements {#requirements}
 
 1. PHP 7.2.5 or higher
@@ -81,7 +88,7 @@ To keep the assets up-to-date and avoid issues in future updates, we **highly re
 @endverbatim
 @endcomponent
 
-## Configuring The Asset Base URL
+## Configuring The Asset Base URL {#configuring-the-asset-base-url}
 
 By default, Livewire serves its JavaScript portion (`livewire.js`) from the following route in your app: `/livewire/livewire.js`.
 

--- a/laravel-echo.blade.php
+++ b/laravel-echo.blade.php
@@ -1,3 +1,7 @@
+* [Introduction](#introduction)
+
+## Introduction {#introduction}
+
 Livewire pairs nicely with Laravel Echo to provide real-time functionality on your web-pages using WebSockets.
 
 @component('components.warning')

--- a/lifecycle-hooks.blade.php
+++ b/lifecycle-hooks.blade.php
@@ -1,5 +1,3 @@
-@include('includes.screencast-cta')
-
 * [Class Hooks](#class-hooks)
 * [Javascript Hooks](#js-hooks)
 

--- a/lifecycle-hooks.blade.php
+++ b/lifecycle-hooks.blade.php
@@ -1,6 +1,9 @@
 @include('includes.screencast-cta')
 
-## Class Hooks
+* [Class Hooks](#class-hooks)
+* [Javascript Hooks](#js-hooks)
+
+## Class Hooks {#class-hooks}
 
 Each Livewire component undergoes a lifecycle. Lifecycle hooks allow you to run code at any part of the component's lifecyle, or before specific properties are updated.
 

--- a/loading-states.blade.php
+++ b/loading-states.blade.php
@@ -1,3 +1,12 @@
+* [Introduction](#introduction)
+* [Toggling elements during "loading" states](#toggling-elements)
+* [Delaying loading indicator](#delaying-loading)
+* [Targeting specific actions](#targeting-actions)
+* [Targeting models](#targeting-models)
+* [Toggling classes](#toggling-classes)
+* [Toggling attributes](#toggling-attributes)
+
+## Introduction {#introduction}
 
 Because Livewire makes a roundtrip to the server every time an action is triggered on the page, there are cases when the page may not react immediately to a user event (like a click). Livewire allows you to easily display loading states, which can make your app feel more responsive.
 

--- a/making-components.blade.php
+++ b/making-components.blade.php
@@ -1,3 +1,7 @@
+* [Introduction](#introduction)
+* [Inline Components](#inline-components)
+
+## Introduction {#introduction}
 
 Run the following artisan command to create a new Livewire component:
 
@@ -29,7 +33,7 @@ Now, the two created files will be in sub-folders:
 * `app/Http/Livewire/Post/Show.php`
 * `resources/views/livewire/post/show.blade.php`
 
-## Inline Components
+## Inline Components {#inline-components}
 If you wish to create Inline components (Component's without `.blade.php` files), you can add the `--inline` flag to the command:
 
 @component('components.code', ['lang' => 'shell'])

--- a/nesting-components.blade.php
+++ b/nesting-components.blade.php
@@ -1,3 +1,8 @@
+* [Introduction](#introduction)
+* [Keeping Track Of Components In A Loop](#keyed-components)
+    * [Sibling Components in a Loop](#sibling-components-in-a-loop)
+
+## Introduction {#introduction}
 
 Livewire supports nesting components. Component nesting can be an extremely powerful technique, but there are a few gotchas worth mentioning up-front:
 
@@ -61,7 +66,7 @@ If you are on Laravel 7 or above, you can use the tag syntax.
 @endslot
 @endcomponent
 
-### Sibling Components in a Loop
+### Sibling Components in a Loop {#sibling-components-in-a-loop}
 
 In some situations, you may find the need to have sibling components inside of a loop, this situation requires additional consideration for the `wire:key` value.
 

--- a/offline-state.blade.php
+++ b/offline-state.blade.php
@@ -1,3 +1,6 @@
+* [Toggling elements](#toggling-elements)
+* [Toggling classes](#toggling-classes)
+* [Toggling attributes](#toggling-attributes)
 
 It's sometimes important to notify a user if they have lost their internet connection. Livewire provides helpful utilities to perform actions based on a user's "offline" state.
 

--- a/package-dev.blade.php
+++ b/package-dev.blade.php
@@ -1,3 +1,4 @@
+* [Registering Custom Components](#registering-components)
 
 ## Registering Custom Components {#registering-components}
 

--- a/pagination.blade.php
+++ b/pagination.blade.php
@@ -1,3 +1,8 @@
+* [Paginating Data](#paginating-data)
+* [Resetting Pagination After Filtering Data](#resetting-pagination)
+* [Multiple paginators on the same page](#multiple-paginators)
+* [Using The Bootstrap Pagination Theme](#custom-pagination-view)
+* [Using A Custom Pagination View](#custom-pagination-view)
 
 Livewire offers the ability to paginate results within a component. This feature hooks into Laravel's native pagination features, so it should feel like an invisible feature to you.
 

--- a/polling.blade.php
+++ b/polling.blade.php
@@ -1,3 +1,8 @@
+* [Introduction](#introduction)
+* [Polling in the background](#polling-background)
+* [Polling only when element is visible](#polling-element-visible)
+
+## Introduction {#introduction}
 
 Livewire offers a directive called `wire:poll` that, when added to an element, will refresh the component every `2s`.
 
@@ -36,7 +41,7 @@ You can also specify a specific action to fire on the polling interval by passin
 Now, the `foo` method on the component will be called every 2 seconds.
 
 
-## Polling in the background
+## Polling in the background {#polling-background}
 
 Livewire reduces polling when the browser tab is in the background so that it doesn't bog down the server with ajax requests unnecessarily.
 Only about 5% of the expected polling requests are kept.
@@ -51,7 +56,7 @@ If you'd like to keep polling at the normal rate even while the tab is in the ba
 @endverbatim
 @endcomponent
 
-## Polling only when element is visible
+## Polling only when element is visible {#polling-element-visible}
 
 If your component isn't always visible in the browser's viewport (further down the page for example), you can opt to only poll the server when an element is visible by adding the `.visible` modifier to `wire:poll`. For example:
 

--- a/prefetching.blade.php
+++ b/prefetching.blade.php
@@ -1,3 +1,6 @@
+* [Introduction](#introduction)
+
+## Introduction {#introduction}
 
 Livewire offers the ability to "prefetch" the result of an action on mouseover. Toggling display content is a common use case.
 

--- a/properties.blade.php
+++ b/properties.blade.php
@@ -1,18 +1,16 @@
-* [Introduction](#introduction) { .text-blue-800 }
-  * [Important Notes](#important-notes) { .font-normal.text-sm.text-blue-800 }
-* [Initializing Properties](#initializing-properties) { .text-blue-800 }
-* [Data Binding](#data-binding) { .text-blue-800 }
-  * [Binding Nested Data](#binding-nested-data) { .font-normal.text-sm.text-blue-800 }
-  * [Debouncing Input](#debouncing-input) { .font-normal.text-sm.text-blue-800 }
-  * [Lazy Updating](#lazy-updating) { .font-normal.text-sm.text-blue-800 }
-  * [Deferred Updating](#deferred-updating) { .font-normal.text-sm.text-blue-800 }
-* [Binding Directly To Model Properties](#binding-models) { .text-blue-800 }
-* [Custom (Wireable) Properties](#wireable-properties) { .text-blue-800 }
-* [Computed Properties](#computed-properties) { .text-blue-800 }
-
-<div>&nbsp;</div>
-
 @include('includes.screencast-cta')
+
+* [Introduction](#introduction)
+  * [Important Notes](#important-notes)
+* [Initializing Properties](#initializing-properties)
+* [Data Binding](#data-binding)
+  * [Binding Nested Data](#binding-nested-data)
+  * [Debouncing Input](#debouncing-input)
+  * [Lazy Updating](#lazy-updating)
+  * [Deferred Updating](#deferred-updating)
+* [Binding Directly To Model Properties](#binding-models)
+* [Custom (Wireable) Properties](#wireable-properties)
+* [Computed Properties](#computed-properties)
 
 ## Introduction {#introduction}
 

--- a/properties.blade.php
+++ b/properties.blade.php
@@ -1,5 +1,3 @@
-@include('includes.screencast-cta')
-
 * [Introduction](#introduction)
   * [Important Notes](#important-notes)
 * [Initializing Properties](#initializing-properties)

--- a/query-string.blade.php
+++ b/query-string.blade.php
@@ -1,3 +1,8 @@
+* [Introduction](#introduction)
+    * [Keeping A Clean Query String](#clean-query-string)
+    * [Query String Aliases](#query-string-aliases)
+
+## Introduction {#introduction}
 
 Sometimes it's useful to update the browser's query string when your component state changes.
 
@@ -72,6 +77,8 @@ class SearchPosts extends Component
 }
 @endslot
 @endcomponent
+
+### Query String Aliases {#query-string-aliases}
 
 Additionally, if you want to modify how properties are represented in the URL, Livewire offers a simple syntax for aliasing query strings.
 

--- a/quickstart.blade.php
+++ b/quickstart.blade.php
@@ -1,5 +1,3 @@
-@include('includes.screencast-cta')
-
 * [Install Livewire](#install-livewire)
 * [Create a component](#create-a-component)
 * [Include the component](#include-the-component)

--- a/quickstart.blade.php
+++ b/quickstart.blade.php
@@ -1,6 +1,13 @@
 @include('includes.screencast-cta')
 
-## Install Livewire
+* [Install Livewire](#install-livewire)
+* [Create a component](#create-a-component)
+* [Include the component](#include-the-component)
+* [View it in the browser](#view-in-browser)
+* [Add "counter" functionality](#add-counter)
+* [View it in the browser](#view-in-browser-finally)
+
+## Install Livewire {#install-livewire}
 
 Include the PHP.
 

--- a/redirecting.blade.php
+++ b/redirecting.blade.php
@@ -1,3 +1,6 @@
+* [Introduction](#introduction)
+
+## Introduction {#introduction}
 
 You may want to redirect from inside a Livewire component to another page in your app. Livewire supports the standard redirect response syntax you are used to using in Laravel controller.
 

--- a/reference.blade.php
+++ b/reference.blade.php
@@ -1,3 +1,15 @@
+* [Template Directives](#template-directives)
+* [Alpine Component Object (`$wire`)](#alpine-component-object)
+* [Global Livewire JavaScript Object](#global-livewire-js)
+* [JavaScript Hooks](#js-hooks)
+* [Component Class Lifecycle Hooks](#component-class-lifecycle)
+* [Component Class Protected Properties](#component-class-protected-properties)
+* [Component Class Traits](#component-class-traits)
+* [Class Methods](#class-methods)
+* [PHP Testing Methods](#php-testing-methods)
+* [Artisan Commands](#artisan-commands)
+* [PHP Lifecycle Hooks](#php-lifecycle-hooks)
+
 Already familiar with Livewire and want to skip the long-form documentation? Here's a giant list of everything available in Livewire.
 
 ### Template Directives {#template-directives}

--- a/render-method.blade.php
+++ b/render-method.blade.php
@@ -1,1 +1,0 @@
-@include('includes.screencast-cta')

--- a/rendering-components.blade.php
+++ b/rendering-components.blade.php
@@ -1,16 +1,14 @@
-* [Inline Components](#inline-components) { .text-blue-800 }
-  * [Parameters](#parameters) { .font-normal.text-sm.text-blue-800 }
-* [Full-Page Components](#page-components) { .text-blue-800 }
-  * [Configuring The Layout Component](#custom-layout) { .font-normal.text-sm.text-blue-800 }
-  * [Route Parameters](#route-params) { .font-normal.text-sm.text-blue-800 }
-  * [Route Model Binding](#route-model-binding) { .font-normal.text-sm.text-blue-800 }
-* [The Render Method](#render-method) { .text-blue-800 }
-  * [Returning Blade Views](#returning-blade) { .font-normal.text-sm.text-blue-800 }
-  * [Returning Template String](#returning-strings) { .font-normal.text-sm.text-blue-800 }
-
-<div>&nbsp;</div>
-
 @include('includes.screencast-cta')
+
+* [Inline Components](#inline-components)
+  * [Parameters](#parameters)
+* [Full-Page Components](#page-components)
+  * [Configuring The Layout Component](#custom-layout)
+  * [Route Parameters](#route-params)
+  * [Route Model Binding](#route-model-binding)
+* [The Render Method](#render-method)
+  * [Returning Blade Views](#returning-blade)
+  * [Returning Template String](#returning-strings)
 
 ## Inline Components {#inline-components}
 

--- a/rendering-components.blade.php
+++ b/rendering-components.blade.php
@@ -1,5 +1,3 @@
-@include('includes.screencast-cta')
-
 * [Inline Components](#inline-components)
   * [Parameters](#parameters)
 * [Full-Page Components](#page-components)

--- a/security.blade.php
+++ b/security.blade.php
@@ -1,3 +1,10 @@
+* [Introduction](#introduction)
+* [Security Measures](#security-measures)
+    * [The Checksum](#the-checksum)
+    * [Persistent Middleware](#persistent-middleware)
+
+## Introduction {#introduction}
+
 To the new Livewire developer, the experience is somewhat magical. It feels as if when the page loads, your Livewire component is living on a server listening for updates from the browser and responding to them in real-time.
 
 This is not far from how other, similar tools like [Phoenix LiveView](https://dockyard.com/blog/2018/12/12/phoenix-liveview-interactive-real-time-apps-no-need-to-write-javascript) work.
@@ -59,7 +66,7 @@ Here is a deeper visualization of the actual component lifecycles during these r
 
 Hopefully now you've adopted a more accurate mental model of how Livewire works under the hood. This will allow you to more intelligently debug problems and understand the performance and security implications of using Livewire.
 
-## Security Measures
+## Security Measures {#security-measures}
 
 Like you learned above, each Livewire request is "stateless" in the sense that there is no long-running server instance maintaining state. The state is stored in the browser and passed back and forth to the server between requests.
 
@@ -67,7 +74,7 @@ Because the state is stored in the browser, it is vulnerable to front-end manipu
 
 In our "counter" example, there are no real negative implications of manipulating something as trivial and ephemeral as the "count" of that component, but in a component with more at stake, for example an "edit post" component with a delete button, security measures need to be in place.
 
-### The Checksum
+### The Checksum {#the-checksum}
 
 The fundamental security underpinning Livewire is a "checksum" that travels along with request/responses and is used to validate that the state from the server hasn't been tampered with in the browser.
 
@@ -84,7 +91,7 @@ A more realistic representation of the Livewire payload for the "counter" would 
 
 Now if a malicous person tampered with the state in the browser between requests, before Livewire handled a component update, it would see that a hash of the payload doesn't match the checksum and throw an error.
 
-### Persistent Middleware
+### Persistent Middleware {#persistent-middleware}
 
 The second security measure Livewire puts in place is "persistent middleware". This means Livewire will capture any authentication/authorization middleware that was used during the "Initial Request" and re-apply it to subsequent requests.
 

--- a/testing.blade.php
+++ b/testing.blade.php
@@ -1,3 +1,10 @@
+* [Introduction](#introduction)
+* [Testing Component Presence](#testing-component-presence)
+* [Testing With Query String Parameters](#testing-querystring)
+* [Testing Components With Passed Data](#testing-passed-data)
+* [All Available Test Methods](#all-testing-methods)
+
+## Introduction {#introduction}
 
 Livewire offers a powerful set of tools for testing your components.
 

--- a/traits.blade.php
+++ b/traits.blade.php
@@ -1,3 +1,7 @@
+* [Introduction](#introduction)
+
+## Introduction {#introduction}
+
 PHP Traits are a great way to re-use functionality between multiple Livewire components.
 
 For example, you might have multiple "data table" components in your application that all share the same logic surrounding sorting.

--- a/troubleshooting.blade.php
+++ b/troubleshooting.blade.php
@@ -1,18 +1,25 @@
+* [Dom Diffing Issues](#dom-diffing-issues)
+    * [Symptoms](#dom-diffing-symptoms)
+    * [Cures](#dom-diffing-cures)
+* [Checksum Issues](#checksum-issues)
+* [Query String Issues](#query-string-issues)
+    * [Symptoms](#query-string-symptoms)
+    * [Cures](#query-string-cures)
 
-## Dom Diffing Issues
+## Dom Diffing Issues {#dom-diffing-issues}
 
 The most common issues encountered by Livewire users has to do with Livewire's DOM diffing/patching system. This is the system that selectively updates elements that have been changed, added, or removed after every component update.
 
 For the most part, this system is reliable, but there are certain cases where Livewire is unable to properly track changes. When this happens, hopefully, a helpful error will be thrown and you can debug with the following guide.
 
-### Symptoms:
+### Symptoms {#dom-diffing-symptoms}
 * An input element loses focus
 * An element or group of elements dissapears suddenly
 * A previously interactive element stops responding to user input
 * A loading indicator mis-fires
 * A user action no longer functions
 
-### Cures:
+### Cures {#dom-diffing-cures}
 * Ensure your component has a single-level root element
 * Add `wire:key` to elements inside loops:
 @component('components.code')
@@ -53,7 +60,7 @@ For the most part, this system is reliable, but there are certain cases where Li
 <div wire:key="bar">...</div>
 @endcomponent
 
-## Checksum Issues
+## Checksum Issues {#checksum-issues}
 
 On every request, Livewire does a "[checksum](https://laravel-livewire.com/docs/security)" but in some cases with arrays, it can throw an exception even when the data inside the array is the same.
 
@@ -76,15 +83,15 @@ class HelloWorld extends Component
 @endverbatim
 @endcomponent
 
-## Query String Issues
+## Query String Issues {#query-string-issues}
 
 Livewire is using the site's `referrer` information when setting the query string. This can lead to conflicts when you are adding security headers to your application through the `referrer-policy`.
 
-### Symptoms:
+### Symptoms {#query-string-symptoms}
 
 * The query string does not get updated at all.
 * The query string does not get updated when the value is empty.
 
-### Cures:
+### Cures {#query-string-cures}
 
 If you do set security headers, make sure the `referrer-policy` value is set to `same-origin`.

--- a/upgrading.blade.php
+++ b/upgrading.blade.php
@@ -1,4 +1,18 @@
-## V2 is Here! 🎉
+* [V2 is Here! 🎉](#v2-is-here)
+* [Update Your Composer Version](#update-your-composer-version)
+* [Update Your Alpine Version](#update-your-alpine-verion)
+* [Update Your Application Code](#update-your-application-code)
+    * [Updated: `$updatesQueryString` to `$queryString`](#query-string)
+    * [Removed: Route::livewire()](#route-livewire)
+* [Removed: Turbolinks Support](#turbolinks)
+* [Changed: `assertSet()`](#assert-set)
+* [Removed: Property Casters](#casters)
+* [Updated: Pagination Views](#pagination)
+* [Updated: JavaScript Hooks](#hooks)
+* [Updated: VueJS Support](#vuejs)
+* [Signing Off](#signing-off)
+
+## V2 is Here! 🎉 {#v2-is-here}
 
 Before we get into the technical upgrade stuff, you might be interested in what philosophical underpinnings are behind these changes.
 
@@ -7,14 +21,14 @@ Before we get into the technical upgrade stuff, you might be interested in what 
 * **Livewire is a back-end interface at its core**. The `wire:click` stuff is just sugar that makes the interface easy to use. With the addition of `$wire`, the underlying power is now apparent: Livewire allows you to interface with backend code, directly and declaratively without the need for imperative/boilerplatey patterns like axios.post(), RESTfull endpoints, controllers, etc...
 * **Livewire is simple to use**. Of all the philosophies I hold, I hold this one the strongest. Livewire should always remain ridiculously easy to use. My goal is that you can easily remember and almost guess its APIs. Before introducing any feature, I scour existing patterns and APIs in Laravel to see if Livewire can use that shared knowledge as leverage for new adopters. A small example is the new `$rules` property. I could have named it anything, but why would I name it anything besides `$rules` (a precedent set by Request objects in Laravel)? If I don't think an API is easy, intuitive, and clear, I wait on the feature and let it simmer until something clear and beautiful emerges. (Or at least that's my goal.)
 
-## Update Your Composer Version
+## Update Your Composer Version {#update-your-composer-version}
 
 1. Update the `livewire/livewire` dependency in your `composer.json` file to `^2.0`
 2. Run `composer update livewire/livewire`
 3. Run `php artisan view:clear`
 4. Run `php artisan livewire:publish --assets` (If you published the assets before)
 
-## Update Your Alpine Version
+## Update Your Alpine Version {#update-your-alpine-verion}
 
 If you are using [AlpineJS](https://github.com/alpinejs/alpine) with Livewire V2, make sure you are on version `2.7.0` or greater.
 
@@ -23,7 +37,7 @@ If you are using [AlpineJS](https://github.com/alpinejs/alpine) with Livewire V2
 <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.7.x/dist/alpine.min.js" defer></script>
 @endcomponent
 
-## Update Your Application Code
+## Update Your Application Code {#update-your-application-code}
 
 Here are the breaking changes and their upgrade instructions in order of impact:
 
@@ -341,7 +355,7 @@ If your Livewire currently depends on the [vue-plugin](https://github.com/livewi
 @endcomponent
 
 
-## Signing Off
+## Signing Off {#signing-off}
 Hopefully, the impact of this upgrade isn't much for you.
 
 If you have questions or corrections to make to this document, please [submit a GitHub issue on the repository.](https://github.com/livewire/livewire/issues/new/choose)


### PR DESCRIPTION
This PR adds TOC to any V2 docs page that doesn't have them and adds any required heading ID's to get them working.

TOC styles and the CTA banner have been added to the main docs app, so they have been removed from these markdown files.