### PR TITLE
Add cure for dom diffing issue

### DIFF
--- a/troubleshooting.blade.php
+++ b/troubleshooting.blade.php
@@ -60,6 +60,17 @@ For the most part, this system is reliable, but there are certain cases where Li
 <div wire:key="bar">...</div>
 @endcomponent
 
+* Ensure there is no leading comment or element outside the main <div> tag. You component must have a div tag that is parent to everthing else.
+
+* This will cause dom diffing issues. The whole component will disappear while trying to update dom.
+@component('components.code')
+<!-- This example requires Tailwind CSS v2.0+ -->
+<div>
+    ...
+</div>
+@endcomponent
+
+
 ## Checksum Issues {#checksum-issues}
 
 On every request, Livewire does a "[checksum](https://laravel-livewire.com/docs/security)" but in some cases with arrays, it can throw an exception even when the data inside the array is the same.


### PR DESCRIPTION
When the component has a leading html comment, the entire component will disappear while trying to diff. This advises how to handle that. It is not mentioned anywhere in the docs or online platforms.