### PR TITLE
Add CORS error alert to the file uploads page

### DIFF
--- a/file-uploads.blade.php
+++ b/file-uploads.blade.php
@@ -331,6 +331,10 @@ return [
 
 Now, when a user uploads a file, the file will never actually hit your server. It will be uploaded directly to your S3 bucket, under the sub-directory: `livewire-tmp/`.
 
+@component('components.warning')
+In case of a CORS error when uploading the file, make sure to configure your receiving end to allow the appropriate headers. In addition to the <code>x-amz-acl</code> header you need to allow the <code>Content-Type</code> header when uploading files.
+@endcomponent
+
 ### Configuring Automatic File Cleanup {#auto-cleanup}
 This temporary directory will fill up with files quickly, therefore, it's important to configure S3 to cleanup files older than 24 hours.
 


### PR DESCRIPTION
In this discussion with myself (https://github.com/livewire/livewire/discussions/4594) I struggled a bit with file uploads to directly upload to an S3 bucket, because I use DO Spaces which blocks requests except you configure the CORS settings properly.

This PR adds an alert to remind livewire users that the `x-amz-acl` and `Content-Type` headers may need to be manually allowed for this feature to work.