### PR TITLE
Fix a misleading class name

### DIFF
--- a/alpine-js.blade.php
+++ b/alpine-js.blade.php
@@ -212,7 +212,7 @@ To demonstrate, consider the dropdown example from before, but now with its `sho
 @component('components.code-component')
 @slot('class')
 @verbatim
-class Dropdown extends Component
+class YourLiveWireComponent extends Component
 {
     public $showDropdown = false;
 


### PR DESCRIPTION
I am pretty sure that this is not right.

- Explanation:
You cannot use Blade component as stated in the docs and use variable usch `public $showDropdown = false;` and function of it within the parent Livewire component.

I tested it and it's not working so perhaps this will help other people as well.

Thanks again and again for the amazing work of Livewire & Alpine ⭐️