### PR TITLE
Added another 'cure' to root-element-cures

### DIFF
--- a/troubleshooting.blade.php
+++ b/troubleshooting.blade.php
@@ -145,3 +145,5 @@ So in our example from above, we have wrapped everything in a `<div>` which gets
     <button wire:click="doSomething">Do Something</button>
 </div> <!-- Added this closing tag for the wrapping div -->
 @endcomponent
+
+Another cause can be using __construct() inside the Livewire class or a Trait.


### PR DESCRIPTION
I got the multiple root error when having a __construct() in a Trait class. While this seems a no brainer, do not use __construct() in a Trait, it happened to one of my developers. PHPStorm also does not show any errors or recommendations when using __construct() in a Trait class. To prevent more people from having the same issue, I added this pull request.