### PR TITLE
update to suggest using numeric key for nested components

### DIFF
--- a/nesting-components.blade.php
+++ b/nesting-components.blade.php
@@ -66,6 +66,8 @@ If you are on Laravel 7 or above, you can use the tag syntax.
 @endslot
 @endcomponent
 
+NB: For best results us an integer for your key value.
+
 ### Sibling Components in a Loop {#sibling-components-in-a-loop}
 
 In some situations, you may find the need to have sibling components inside of a loop, this situation requires additional consideration for the `wire:key` value.

--- a/nesting-components.blade.php
+++ b/nesting-components.blade.php
@@ -66,7 +66,7 @@ If you are on Laravel 7 or above, you can use the tag syntax.
 @endslot
 @endcomponent
 
-NB: For best results us an integer for your key value.
+For best results us an integer for your key value.
 
 ### Sibling Components in a Loop {#sibling-components-in-a-loop}
 


### PR DESCRIPTION
I have found that using a unique alphanumeric key can cause issues, whereas using a numberic key seems to work consistently.  Worth specifying this in the docs.