### PR TITLE
Add docs for max_upload_time

### DIFF
--- a/file-uploads.blade.php
+++ b/file-uploads.blade.php
@@ -478,3 +478,18 @@ return [
 ];
 @endslot
 @endcomponent
+
+### Maximum Upload Time
+File uploads are automatically invalidated if they take longer than 5 minutes. You can customize this with the following configuration key:
+
+@component('components.code-component')
+@slot('class')
+return [
+    ...
+    'temporary_file_upload' => [
+        ...
+        'max_upload_time' => 5,
+    ],
+];
+@endslot
+@endcomponent


### PR DESCRIPTION
We are running an app with ~1900 users. Since we implemented an upload with Livewire we occasionally got complaints that the upload doesn't work. Files that are uploaded on our app usually have a size between 50 to 75Mb. I finally figured out that the failed upload is only occurring on slow internet connections. It took a while until I found that setting, therefore I made this PR so others may be able to find this easier :)