### PR TITLE
Update events.blade.php

### DIFF
--- a/events.blade.php
+++ b/events.blade.php
@@ -192,7 +192,7 @@ window.addEventListener('name-updated', event => {
 AlpineJS allows you to easily listen for these window events within your HTML:
 
 @component('components.code', ['lang' => 'blade'])
-<div x-data="{ open: false }" @name-updated.window="open = false">
+<div x-data="{ open: false }" @name-updated.window="open = true">
     <!-- Modal with a Livewire name update form -->
 </div>
 @endcomponent


### PR DESCRIPTION
After "name-updated" is called on window, the value of "open" must be changed to "true" in order to display the modal.