### PR TITLE
Correct `2.x` Installation Command

### DIFF
--- a/installation.blade.php
+++ b/installation.blade.php
@@ -15,7 +15,7 @@ Visit the [composer.json file on Github](https://github.com/livewire/livewire/bl
 ## Install The Package {#install-package}
 
 @component('components.code', ['lang' => 'shell'])
-composer require livewire/livewire
+composer require livewire/livewire:^2.0
 @endcomponent
 
 ## Include The Assets {#include-js}


### PR DESCRIPTION
With the release of version 3, we need to ensure that the command to install V2 is using the `^2.0`, otherwise V3 will be installed.